### PR TITLE
Release wf-uicomponents 0.5.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wf-uicomponents",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "ignore": [
     "bower_components",
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "1.3.1",
     "hammerjs": "1.0.5",
-    "wf-common": "git@github.com:WebFilings/wf-common.git#672fa295dd6bdbe426de3bcf489678efc4475066"
+    "wf-common": "git@github.com:WebFilings/wf-common.git#0.1.12"
   },
   "devDependencies": {
     "jquery": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wf-uicomponents",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "UI Components that support a rich HTML5 user experience.",
   "private": true,
   "repository": {


### PR DESCRIPTION
PR's included in this release
 https://github.com/WebFilings/wf-uicomponents/pull/10
 https://github.com/WebFilings/wf-uicomponents/pull/11
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-uicomponents

# do not skip these!
$ git fetch && git checkout Release0.5.2
$ ./init.sh
$ grunt qa
```

@trentgrover-wf @jasonwelch-wf @shanesizer-wf @jasonjohnson-wf @timmccall-wf @lancefisher-wf @nathanevans-wf @robbecker-wf @mikethiesen-wf @patkujawa-wf 
