### PR TITLE
Make JavaScript Animations Smoother

### DIFF
--- a/src/awesome_map/TransformUtil.js
+++ b/src/awesome_map/TransformUtil.js
@@ -172,8 +172,10 @@ define(function(require) {
                 // If the transformation has been cancelled,
                 // resolve the promise with the state of the last step; ...
                 if (cancelled) {
+                    // Round off translation values for ease of comparison elsewhere.
                     stepState.translateX = Math.ceil(stepState.translateX);
                     stepState.translateY = Math.ceil(stepState.translateY);
+                    TransformUtil.applyTransform(target, stepState);
                     return done(stepState);
                 }
 


### PR DESCRIPTION
Use floating point animation step values for JavaScript animations.
This makes for smoother transitions between steps. Currently not
using JS animations for anything, but in might in the future in
certain cases....

@lancefisher-wf 
@patkujawa-wf 
@robbecker-wf 
@shanesizer-wf 
