### PR TITLE
Add ScrollList#scrollToPosition

### DIFF
--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -628,15 +628,15 @@ define(function(require) {
             var listMap = this.getListMap();
             var currentState = listMap.getCurrentTransformState();
             var currentScale = currentState.scale;
-            var x = options.x === undefined ? -currentState.translateX / currentScale : options.x;
-            var y = options.y === undefined ? -currentState.translateY / currentScale : options.y;
+            var x = options.x === undefined ? -currentState.translateX : options.x * currentScale;
+            var y = options.y === undefined ? -currentState.translateY : options.y * currentScale;
 
             // Constrain position to within bounds.
             var layout = this.getLayout();
             var listSize = layout.getSize();
             var viewportSize = layout.getViewportSize();
-            x = constrain(x, 0, listSize.width - viewportSize.width);
-            y = constrain(y, 0, listSize.height - viewportSize.height);
+            x = constrain(x, 0, listSize.width * currentScale - viewportSize.width);
+            y = constrain(y, 0, listSize.height * currentScale - viewportSize.height);
 
             // Ensure placeholders exist at target position to prevent flash of
             // emptiness upon scrolling to target position.
@@ -651,8 +651,8 @@ define(function(require) {
 
             // If in flow mode, go to the position:
             this._listMap.panTo({
-                x: -x * currentScale,
-                y: -y * currentScale,
+                x: -x,
+                y: -y,
                 done: options.done
             });
         },

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -722,9 +722,9 @@ define(function(require) {
                 testScrollList({ mode: 'flow' }, function(scrollList) {
                     setup(scrollList);
 
-                    scrollList.scrollToPosition({ x: 1000 });
+                    scrollList.scrollToPosition({ x: 2000 });
                     expect(listMap.panTo.mostRecentCall.args[0].x)
-                        .toBe(listState.scale * (viewportSize.width - listSize.width));
+                        .toBe(viewportSize.width - listSize.width * listState.scale);
 
                     scrollList.scrollToPosition({ x: -100 });
                     expect(listMap.panTo.mostRecentCall.args[0].x).toBe(0);
@@ -736,7 +736,7 @@ define(function(require) {
 
                     scrollList.scrollToPosition({ y: 1000 });
                     expect(listMap.panTo.mostRecentCall.args[0].y)
-                        .toBe(listState.scale * (viewportSize.height - listSize.height));
+                        .toBe(viewportSize.height - listSize.height * listState.scale);
 
                     scrollList.scrollToPosition({ y: -100 });
                     expect(listMap.panTo.mostRecentCall.args[0].y).toBe(0);
@@ -753,13 +753,13 @@ define(function(require) {
                     spyOn(layout, 'render');
 
                     // Vertical support:
-                    scrollList.scrollToPosition({ y: 500 });
-                    expect(layout.setScrollPosition.mostRecentCall.args[0].top).toBe(500);
+                    scrollList.scrollToPosition({ y: 200 });
+                    expect(layout.setScrollPosition.mostRecentCall.args[0].top).toBe(400);
                     expect(layout.render.calls.length).toBe(1);
 
                     // Horizontal support:
-                    scrollList.scrollToPosition({ x: 500 });
-                    expect(layout.setScrollPosition.mostRecentCall.args[0].left).toBe(500);
+                    scrollList.scrollToPosition({ x: 300 });
+                    expect(layout.setScrollPosition.mostRecentCall.args[0].left).toBe(600);
                     expect(layout.render.calls.length).toBe(2);
                 });
             });


### PR DESCRIPTION
Add method to ScrollList to enable scrolling to a position within the list, as opposed to just scrolling to the top of an item.
## Unit Tests
- Added tests for new method.
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-js-uicomponents.git
$ cd wf-js-uicomponents

# do not skip these!
$ git fetch && 
git checkout scroll_to_position && 
./init.sh && 
grunt qa
```
- Should see no console errors.
- Open the scroll list example.
- Exercise the API via the dev console. `scrollList` is a global reference to the instance in the page. So simply `scrollList.scrollToPosition(...)`.

@lancefisher-wf 
@robbecker-wf 
@patkujawa-wf 
