### PR TITLE
Change ScrollList#zoomTo Method Signature

### DIFF
--- a/examples/scroll_list/scroll-list.js
+++ b/examples/scroll_list/scroll-list.js
@@ -208,7 +208,7 @@ require([
 
         $('#zoomToScale').submit(function() {
             var scale = parseInt(this.elements.zoomTo.value, 10) / 100;
-            scrollList.zoomTo(scale);
+            scrollList.zoomTo({ scale: scale });
             $(':focus').blur();
             return false;
         });

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -600,15 +600,19 @@ define(function(require) {
         /**
          * Zooms to the specified scale.
          * @method ScrollList#zoomTo
-         * @param {number} scale - The target scale.
-         * @param {number} [duration] - The animation duration, in ms.
-         * @param {Function} [done] - Callback invoked when the zoom is complete.
+         * @param {Object} options
+         * @param {number} options.scale - The target scale.
+         * @param {number} [options.duration] - The animation duration, in ms.
+         * @param {Function} [options.done] - Callback invoked when the zoom is complete.
          */
-        zoomTo: function(scale, duration, done) {
+        zoomTo: function(options) {
+            if (options.scale === undefined) {
+                throw new Error('ScrollList#zoomToScale: scale is required.');
+            }
             (this.getCurrentItemMap() || this._listMap).zoomTo({
-                scale: this._scaleTranslator.toMapScale(scale),
-                duration: duration,
-                done: done
+                scale: this._scaleTranslator.toMapScale(options.scale),
+                duration: options.duration,
+                done: options.done
             });
         },
 

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -673,7 +673,7 @@ define(function(require) {
                 spyOn(translator, 'toMapScale').andReturn(translatedScale);
                 spyOn(targetMap, 'zoomTo');
 
-                scrollList.zoomTo(scale, duration, done);
+                scrollList.zoomTo({ scale: scale, duration: duration, done: done});
 
                 expect(translator.toMapScale).toHaveBeenCalledWith(scale);
                 expect(targetMap.zoomTo).toHaveBeenCalledWith({


### PR DESCRIPTION
Change ScrollList#zoomTo method signature to accept and single
arg of options, to align it with other methods.
## Unit Tests
- Updated to reflect API changes
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-js-uicomponents.git
$ cd wf-js-uicomponents

# do not skip these!
$ git fetch && 
git checkout change_zoom_method_signature && 
./init.sh && 
grunt qa
```
- Should see no console errors.
- Open ScrollList demo.
- Should be able to enter a different zoom level and have the scroll list update accordingly.

@lancefisher-wf 
@robbecker-wf 
@patkujawa-wf 
