### PR TITLE
Fix Broken Logic in VerticalLayout#getCurrentItemIndex

### DIFF
--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -25,6 +25,7 @@ define(function(require) {
 
     describe('VerticalLayout', function() {
 
+        var viewportSize = { width: 200, height: 500 };
         var $viewport = $('<div>').css({ position: 'absolute', top: -10000 });
         var itemMetadata = [];
 
@@ -36,7 +37,7 @@ define(function(require) {
         }
 
         beforeEach(function() {
-            $viewport.empty().appendTo('body').css({ width: 200, height: 500 });
+            $viewport.empty().appendTo('body').css(viewportSize);
 
             itemMetadata = [
                 { width: 100, height: 200 },
@@ -259,6 +260,16 @@ define(function(require) {
                 layout = createVerticalLayout();
 
                 expect(layout.getCurrentItemIndex()).toBe(1);
+            });
+            
+            it('should return the item nearest the viewport center if none intersects', function() {
+                itemMetadata = [{
+                    width: viewportSize.width,
+                    height: viewportSize.height / 4
+                }];
+                layout = createVerticalLayout({ flow: true });
+
+                expect(layout.getCurrentItemIndex()).toBe(0);
             });
         });
 


### PR DESCRIPTION
The `VerticalLayout#getCurrentItemIndex` method will throw if no
item intersects the viewport center. In such cases, return the index
of the item that is nearest the viewport center.
## Unit Tests
- New test for asserting proper handling of error case.
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-uicomponents

# do not skip these!
$ git fetch && 
git checkout fix_broken_current_item_index && 
./init.sh && 
grunt qa
```
- Should see no console errors.

@lancefisher-wf 
@robbecker-wf 
@patkujawa-wf 
