### PR TITLE
Fix ScrollList Hit Testing

### DIFF
--- a/src/scroll_list/HitTester.js
+++ b/src/scroll_list/HitTester.js
@@ -17,12 +17,13 @@
 define(function() {
     'use strict';
 
-    function getHitData(itemLayout, position, bounds) {
+    function getHitData(itemLayout, position, bounds, mapScale) {
+        var scaleFactor = mapScale * itemLayout.scaleToFit;
         return {
             index: itemLayout.itemIndex,
             position: {
-                x: Math.floor((position.x - bounds.left) / itemLayout.scaleToFit),
-                y: Math.floor((position.y - bounds.top) / itemLayout.scaleToFit)
+                x: Math.floor((position.x - bounds.left) / scaleFactor),
+                y: Math.floor((position.y - bounds.top) / scaleFactor)
             }
         };
     }
@@ -77,7 +78,7 @@ define(function() {
             if (position.x >= validBounds.left && position.x <= validBounds.right &&
                 position.y >= validBounds.top && position.y <= validBounds.bottom) {
 
-                return getHitData(itemLayout, position, validBounds);
+                return getHitData(itemLayout, position, validBounds, mapScale);
             }
 
             return false;
@@ -124,7 +125,7 @@ define(function() {
                 if (position.x >= validBounds.left && position.x <= validBounds.right &&
                     position.y >= validBounds.top && position.y <= validBounds.bottom) {
 
-                    return getHitData(itemLayout, position, validBounds);
+                    return getHitData(itemLayout, position, validBounds, mapScale);
                 }
             }
 

--- a/test/scroll_list/HItTesterSpec.js
+++ b/test/scroll_list/HItTesterSpec.js
@@ -95,13 +95,13 @@ define(function(require) {
                 itemLayout.outerWidth = 100;
                 itemLayout.outerHeight = 100;
                 itemLayout.scaleToFit = 0.5;
-                event.position = { x: 50, y: 50 };
-                var state = new TransformState({ translateX: 0, translateY: 0, scale: 1 });
+                event.position = { x: 300, y: 300 };
+                var state = new TransformState({ translateX: 100, translateY: 100, scale: 2 });
                 var result = HitTester.testItemMap(scrollList, event, state);
 
                 expect(result).toEqual({
                     index: itemLayout.itemIndex,
-                    position: { x: 100, y: 100 }
+                    position: { x: 200, y: 200 }
                 });
             });
         });
@@ -200,13 +200,13 @@ define(function(require) {
                 itemLayout.bottom = 100;
                 itemLayout.left = 0;
                 itemLayout.scaleToFit = 0.5;
-                event.position = { x: 50, y: 50 };
-                var state = new TransformState({ translateX: 0, translateY: 0, scale: 1 });
+                event.position = { x: 300, y: 300 };
+                var state = new TransformState({ translateX: 100, translateY: 100, scale: 2 });
                 var result = HitTester.testListMap(scrollList, event, state);
 
                 expect(result).toEqual({
                     index: itemLayout.itemIndex,
-                    position: { x: 100, y: 100 }
+                    position: { x: 200, y: 200 }
                 });
             });
         });


### PR DESCRIPTION
When performing hit testing, the position returned from successful
tests did not correlate to the defined size of the item passed
into the scroll list. Instead, it was relative to the rendered size of
the item.

@lancefisher-wf 
@patkujawa-wf 
@robbecker-wf 
