### PR TITLE
Account for top offset in hit test

### DIFF
--- a/src/scroll_list/HitTester.js
+++ b/src/scroll_list/HitTester.js
@@ -68,15 +68,16 @@ define(function() {
             // This is awful stuff. Tricky currently due to using the item map
             // to center and position content, overriding the layout stuff.
             // Ideally this logic would live in the layout.
+            var yTranslateAndOffset = state.translateY + itemLayout.offsetTop;
             var validBounds = {
-                top: state.translateY + itemLayout.paddingTop * mapScale,
+                top: yTranslateAndOffset + itemLayout.paddingTop * mapScale,
                 right: state.translateX + (itemLayout.outerWidth - itemLayout.paddingRight) * mapScale,
-                bottom: state.translateY + (itemLayout.outerHeight - itemLayout.paddingBottom) * mapScale,
+                bottom: yTranslateAndOffset + (itemLayout.outerHeight - itemLayout.paddingBottom) * mapScale,
                 left: state.translateX + itemLayout.paddingLeft * mapScale
             };
 
-            if (position.x >= validBounds.left && position.x <= validBounds.right &&
-                position.y >= validBounds.top && position.y <= validBounds.bottom) {
+            if (validBounds.left <= position.x && position.x <= validBounds.right &&
+                validBounds.top <= position.y && position.y <= validBounds.bottom) {
 
                 return getHitData(itemLayout, position, validBounds, mapScale);
             }

--- a/test/scroll_list/HitTesterSpec.js
+++ b/test/scroll_list/HitTesterSpec.js
@@ -91,6 +91,25 @@ define(function(require) {
                     expect(result).toBe(false);
                 });
             });
+            describe('when itemLayout has an offsetTop', function() {
+                it('should test correctly at top edge', function() {
+                    itemLayout.outerHeight = 110;
+                    itemLayout.paddingTop = 10;
+                    itemLayout.offsetTop = 200;
+                    event.position = {
+                        x: 0,
+                        y: 310 // outerHeight + offsetTop
+                    };
+                    var state = new TransformState({ translateY: 100 });
+                    var result = HitTester.testItemMap(scrollList, event, state);
+                    expect(result).toBeTruthy();
+                    // Now bump one px outside.
+                    state.translateY = 101;
+                    result = HitTester.testItemMap(scrollList, event, state);
+                    expect(result).toBe(false);
+                });
+
+            });
             it('should translate successful hit positions to be relative to original item size', function() {
                 itemLayout.outerWidth = 100;
                 itemLayout.outerHeight = 100;


### PR DESCRIPTION
Previously, HitTester.testItemMap() would not take into account
the offsetTop when testing for an event in the hit area. This is
used in peek mode to determine if there is a mouse move or click in a
particular bounding box on the page. The bounding box coordinates are
expected to be determined relative to the page, and the offsetTop
should be added to determine where this is.
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-js-uicomponents

# do not skip these!
git fetch && git checkout account_for_top_offset_in_hit_test
./init.sh
grunt
```

All unit tests should pass.

@robbecker-wf @patkujawa-wf @timmccall-wf @robbielamb-wf 
