### PR TITLE
Fix ScrollList ItemMap Hit Testing

### DIFF
--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -132,7 +132,7 @@ define(function(require) {
             map.onInteraction(function(source, args) {
                 var newArgs = { event: args.event };
                 var fn = HitTester[options.mode === ScrollModes.FLOW ? 'testListMap' : 'testItemMap'];
-                var hit = fn(scrollList, args.event, args.currentState);
+                var hit = fn(scrollList, args.event);
                 if (hit) {
                     newArgs.itemIndex = hit.index;
                     newArgs.itemPosition = hit.position;

--- a/src/scroll_list/HitTester.js
+++ b/src/scroll_list/HitTester.js
@@ -50,16 +50,22 @@ define(function() {
          * @method
          * @param {ScrollList} scrollList
          * @param {InteractionEvent} event - The interaction event under test.
-         * @param {TransformState} state - The current transform state of the item map.
          * @return {boolean|{ index: number, position: { x: number, y: number }}}
          */
-        testItemMap: function(scrollList, event, state) {
+        testItemMap: function(scrollList, event) {
             if (!event.position) {
                 return false;
             }
 
-            var position = event.position;
+            // Item map may not exist after list invalidation, which happens
+            // during window/container resize event cycles.
+            var itemMap = scrollList.getCurrentItemMap();
+            if (!itemMap) {
+                return false;
+            }
 
+            var position = event.position;
+            var state = itemMap.getCurrentTransformState();
             var mapScale = state.scale;
             var layout = scrollList.getLayout();
             var currentItemIndex = layout.getCurrentItemIndex();
@@ -68,11 +74,10 @@ define(function() {
             // This is awful stuff. Tricky currently due to using the item map
             // to center and position content, overriding the layout stuff.
             // Ideally this logic would live in the layout.
-            var yTranslateAndOffset = state.translateY + itemLayout.offsetTop;
             var validBounds = {
-                top: yTranslateAndOffset + itemLayout.paddingTop * mapScale,
+                top: state.translateY + itemLayout.paddingTop * mapScale,
                 right: state.translateX + (itemLayout.outerWidth - itemLayout.paddingRight) * mapScale,
-                bottom: yTranslateAndOffset + (itemLayout.outerHeight - itemLayout.paddingBottom) * mapScale,
+                bottom: state.translateY + (itemLayout.outerHeight - itemLayout.paddingBottom) * mapScale,
                 left: state.translateX + itemLayout.paddingLeft * mapScale
             };
 
@@ -93,15 +98,16 @@ define(function() {
          * @method
          * @param {ScrollList} scrollList
          * @param {InteractionEvent} event - The interaction event under test.
-         * @param {TransformState} state - The current transform state of the item map.
          * @return {boolean|{ index: number, position: { x: number, y: number }}}
          */
-        testListMap: function(scrollList, event, state) {
+        testListMap: function(scrollList, event) {
             if (!event.position) {
                 return false;
             }
 
+            var listMap = scrollList.getListMap();
             var position = event.position;
+            var state = listMap.getCurrentTransformState();
             var mapScale = state.scale;
 
             var layout = scrollList.getLayout();


### PR DESCRIPTION
Hit testing fails for item maps in a scroll list due to the calling
code passing in the current transform state for the list map, not for
the current item map. Fix by making the hit testing functions
responsible for looking up transform state and when testing item maps
look up the transform state for the item map, not the list map.
## Unit Tests
- Removed tests for previous fix that did not resolve this bug.
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-uicomponents

# do not skip these!
$ git fetch && 
git checkout fix_item_map_hit_testing && 
./init.sh && 
grunt
```
- Should see no console errors.
- Please refer to internal WF ticket for further instructions.

@lancefisher-wf 
@patkujawa-wf 
@robbecker-wf 
Attn: @robbielamb-wf 
