### PR TITLE
Normalize Event Position

### DIFF
--- a/src/awesome_map/AwesomeMap.js
+++ b/src/awesome_map/AwesomeMap.js
@@ -384,6 +384,15 @@ define(function(require) {
         },
 
         /**
+         * Gets the viewport element.
+         * @method AwesomeMap#getViewport
+         * @returns {HTMLElement}
+         */
+        getViewport: function() {
+            return this._viewport;
+        },
+
+        /**
          * Gets the dimensions of the viewport.
          * @method AwesomeMap#getViewportDimensions
          * @returns {{
@@ -626,6 +635,8 @@ define(function(require) {
             else if (eventType === EventTypes.RESIZE) {
                 this.invalidateViewportDimensions();
             }
+
+            this._normalizeEventPosition(event);
 
             // Dispatch to observers; they can cancel the event by returning false.
             this.onInteraction.dispatch([
@@ -893,6 +904,23 @@ define(function(require) {
                 this._contentDimensions = null;
                 contentDimensions = this.getContentDimensions();
             }
+        },
+
+        /**
+         * Normalize the position of the interaction event so that it is relative to the top/left
+         * of the viewport. If this map is disabled during after touch but before release,
+         * it will continue receiving events; however, the position of those events will be relative
+         * to the browser window, and not the hit area covering the viewport.
+         * @param {InteractionEvent} event - The interaction event
+         * @private
+         */
+        _normalizeEventPosition: function(event) {
+            if (!(this.isDisabled() && event.position)) {
+                return;
+            }
+            var boundingRect = this._viewport.getBoundingClientRect();
+            event.position.x -= boundingRect.left;
+            event.position.y -= boundingRect.top;
         },
 
         /**

--- a/test/awesome_map/AwesomeMapSpec.js
+++ b/test/awesome_map/AwesomeMapSpec.js
@@ -742,6 +742,32 @@ define(function(require) {
                 ], jasmine.any(Function));
             });
 
+            it('should normalize the event position relative to the viewport origin if disabled', function() {
+                var evt = createInteractionEvent(null);
+                evt.position = {
+                    x: 100,
+                    y: 200
+                };
+                var viewportOffset = {
+                    left: 10,
+                    top: 20
+                };
+                var viewport = awesomeMap.getViewport();
+                spyOn(viewport, 'getBoundingClientRect').andReturn(viewportOffset);
+
+                spyOn(awesomeMap, 'isDisabled').andReturn(true);
+                spyOn(awesomeMap, 'getCurrentTransformState').andReturn(new TransformState());
+                spyOn(awesomeMap.onInteraction, 'dispatch');
+
+                awesomeMap.handleInteractionEvent(null, { event: evt });
+
+                expect(awesomeMap.onInteraction.dispatch).toHaveBeenCalled();
+                var args = awesomeMap.onInteraction.dispatch.mostRecentCall.args[0];
+                var dispatchedEventPosition = args[1].event.position;
+                expect(dispatchedEventPosition.x).toBe(100 - 10);
+                expect(dispatchedEventPosition.y).toBe(200 - 20);
+            });
+
             it('should set current state to end state of event transformation', function() {
                 var evt = createInteractionEvent(EventTypes.Drag);
 

--- a/test/scroll_list/ViewportResizeInterceptorSpec.js
+++ b/test/scroll_list/ViewportResizeInterceptorSpec.js
@@ -43,6 +43,7 @@ define(function(require) {
 
         afterEach(function() {
             $host.remove();
+            awesomeMap.dispose();
         });
 
         it('should return false to cancel the event and stop propogation to item maps', function() {


### PR DESCRIPTION
If the AwesomeMap is disabled after a touch, but before a release,
then it will continue to emit InteractionEvents. However, the position
of these events will be relative to the window, not the viewport
hosting the AwesomeMap. Normalize the event positions to ensure
predictability in client code.
## Unit Tests
- Cover normalization
## How To +10/QA

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-

# do not skip these!
$ git fetch && 
git checkout normalize_event_position && 
./init.sh && 
grunt qa
```
- Should see no console errors.
- All tests should pass

@lancefisher-wf 
@patkujawa-wf 
@georgelesica-wf 
