### PR TITLE
Fix for Single mode in ScrollList -  Make it stop at boundaries.

### DIFF
--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -55,8 +55,7 @@ define(function(require) {
          */
         createItemMap: function(scrollList, host) {
             var options = scrollList.getOptions();
-            var yBoundaryMode = 'slow';
-            if( options.mode === ScrollModes.SINGLE ) yBoundaryMode = 'stop';
+            var yBoundaryMode = options.mode === ScrollModes.SINGLE ? 'stop' : 'slow';
             var map = new AwesomeMap(host, {
                 touchScrollingEnabled: options.touchScrollingEnabled
             });


### PR DESCRIPTION
# How to +10/QA
- Run `grunt qa`
- Go to http://0.0.0.0:9000/examples/scroll_list/?scroll=single
  - Verify that clicking and dragging to the top or bottom of the viewport results in a hard stop, instead of a slow boundary (and snapback)
- Go to http://0.0.0.0:9000/examples/scroll_list/?scroll=peek
  - Verify that click-and-drag/swipe still result in a slow boundary at the top and bottom of the list, and allows peeks to the next or previous page.
- Go to http://0.0.0.0:9000/examples/scroll_list/?scroll=flow
  - Verify that the top and bottom of the list still has a slow boundary during click-and-drag/swipe

@timmccall-wf @lancefisher-wf @patkujawa-wf @georgelesica-wf 
