### PR TITLE
Fix ScrollBar Exceeding Viewport Top/Bottom

### DIFF
--- a/src/scroll_bar/ScrollBar.js
+++ b/src/scroll_bar/ScrollBar.js
@@ -19,6 +19,7 @@ define(function(require) {
 
     var requestAnimFrame = require('wf-js-common/requestAnimationFrame');
     var EventTypes = require('wf-js-uicomponents/awesome_map/EventTypes');
+    var DestroyUtil = require('wf-js-common/DestroyUtil');
 
     /**
      * Creates a new ScrollBar with the given ScrollList and options.
@@ -80,6 +81,8 @@ define(function(require) {
 
         this._options = options;
 
+        this._disposed = false;
+
         this._layout = scrollList.getLayout();
 
         this._TOTAL_ITEMS = scrollList.getItemSizeCollection ? scrollList.getItemSizeCollection()._items.length :
@@ -107,11 +110,10 @@ define(function(require) {
 
         // Match the scroll bar positioning to the users scrolling
         this._listMap.onTranslationChanged(function() {
-            if (that._scrollbarScrolling) {
-                return;
-            }
             requestAnimFrame(function() {
-                that._placeScrollBar();
+                if (!that._scrollbarScrolling && !that._disposed) {
+                    that._placeScrollBar();
+                }
             });
         });
 
@@ -189,6 +191,8 @@ define(function(require) {
             this._elements.scrollbar.removeEventListener('mousedown', this._mousedownHandler);
             this._elements.scrollbarContainer.removeChild(this._elements.scrollbar);
             this._parent.removeChild(this._elements.scrollbarContainer);
+            DestroyUtil.destroy(this);
+            this._disposed = true;
         },
 
         //---------------------------------------------------------

--- a/test/scroll_bar/ScrollBarSpec.js
+++ b/test/scroll_bar/ScrollBarSpec.js
@@ -36,15 +36,6 @@ define(function(require) {
             ]
         });
 
-        $('<div id="scrolllist-host"></div>').css({ position: 'absolute', top: -10000, width: 500, height: 500 }).appendTo('body');
-        scrollList = new ScrollList(document.getElementById('scrolllist-host'), itemSizeCollection, {
-            mode: 'flow',
-            fit: 'auto',
-            padding: 10,
-            gap: 10,
-            concurrentContentLimit: 3
-        });
-
         initialize = function() {
             options = {};
             options.scrollbarId = 'scroll-bar';
@@ -57,14 +48,13 @@ define(function(require) {
 
         function checkScrollBarAtBottom () {
             var scrollBarEL = document.getElementById('scroll-bar');
-            scrollList.scrollToPosition({ y: scrollList.getLayout().getSize().height });
 
             scrollBar._placeScrollBar();
 
             var position = scrollBarEL.style.top;
             position = parseInt(position, 10);
 
-            expect(position).toEqual(Math.round(scrollBar._availableScrollbarHeight));
+            expect(position).toEqual(Math.floor(scrollBar._availableScrollbarHeight));
         }
 
         function checkForScrollPastEnd () {
@@ -99,6 +89,15 @@ define(function(require) {
         }
 
         beforeEach(function() {
+            $('<div id="scrolllist-host"></div>').css({ position: 'absolute', top: -10000, width: 500, height: 500 }).appendTo('body');
+            scrollList = new ScrollList(document.getElementById('scrolllist-host'), itemSizeCollection, {
+                mode: 'flow',
+                fit: 'auto',
+                padding: 10,
+                gap: 10,
+                concurrentContentLimit: 3
+            });
+
             $parent = $('<div id="scroll-bar-parent"></div>');
             $parent.empty().css({ position: 'absolute', top: -10000, width: 500, height: 500 }).appendTo('body');
             parentEl = $parent[0];
@@ -109,6 +108,8 @@ define(function(require) {
                 scrollBar.dispose();
             }
             $parent.remove();
+            scrollList.dispose();
+            $('#scrolllist-host').remove();
         });
 
         it('should initialize the ScrollBar with the given parameters', function() {
@@ -195,7 +196,7 @@ define(function(require) {
         });
 
         describe('when the ScrollList is shorter than the viewport', function () {
-            beforeEach(function() {
+            it('should not show the scrollbar', function() {
                 initialize();
                 var listMap = scrollList.getListMap();
                 listMap.transform({
@@ -203,18 +204,7 @@ define(function(require) {
                     y: 0,
                     scale: listMap.getCurrentTransformState().scale * 0.1
                 });
-            });
 
-            afterEach(function() {
-                var listMap = scrollList.getListMap();
-                listMap.transform({
-                    x: 0,
-                    y: 0,
-                    scale: listMap.getCurrentTransformState().scale * 10
-                });
-            });
-
-            it('should not show the scrollbar', function() {
                 expect(scrollBar._scrollbarHeight).toBe(0);
             });
         });
@@ -225,7 +215,7 @@ define(function(require) {
                 var listMap = scrollList.getListMap();
                 listMap.transform({
                     x: 0,
-                    y: 0,
+                    y: -scrollList._layout.getSize().height * 10,
                     scale: listMap.getCurrentTransformState().scale + 0.5
                 });
             });
@@ -247,7 +237,7 @@ define(function(require) {
                 var listMap = scrollList.getListMap();
                 listMap.transform({
                     x: 0,
-                    y: -scrollList._layout.getSize().height,
+                    y: -scrollList._layout.getSize().height * 10,
                     scale: listMap.getCurrentTransformState().scale - 0.5
                 });
             });
@@ -257,6 +247,8 @@ define(function(require) {
             });
 
             it('should put the ScrollBar at the bottom when the ScrollList is scrolled to the end', function() {
+                scrollBar._placeScrollBar();
+
                 checkScrollBarAtBottom();
             });
         });


### PR DESCRIPTION
There are two ScrollBar bugs that this PR addresses.
- When the ScrollList is dragged above or below it's bounds, the ScrollBar also exceeded it's bounds.
- When the ScrollList was zoomed out such that the ScrollList was shorter than the viewport, the ScrollBar would become taller than the viewport.

Solutions
- The ScrollBar positioning is now bound between `0` and the height of the viewport minus the height of the ScrollBar.
- When the ScrollList is shorter than the viewport, the ScrollBar height is set to `0`, since it isn't necessary to scroll something that is already completely visible.
## **Unit Tests**

Check that the ScrollBar height is set to zero when the ScrollList is zoomed out far enough.
## **How To +10/QA**

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-uicomponents

# do not skip these!
$ git fetch && 
git checkout HY-1094 && 
./init.sh && 
grunt qa
```
- All tests should pass with no console errors
- In the ScrollList Demo, set the Fake Document to have 1 page. You should not see the ScrollBar. Zoom in, and the ScrollBar should appear.
- At the top or bottom of the page, click and drag so that the grey space above/below the ScrollList is visible. The ScrollBar should not move to overlap the header or footer.

---

Please review: @timmccall-wf @shanesizer-wf @lancefisher-wf 
FYA: @joshschlick-wf 
