### PR TITLE
KeyNavigator: Jumps off of canvas when the left key is pressed multiple times

### DIFF
--- a/src/scroll_list/KeyNavigator.js
+++ b/src/scroll_list/KeyNavigator.js
@@ -133,13 +133,23 @@ define(function(require) {
          *        Which horizontal direction to move in (left or right)
          */
         _moveX: function(direction) {
-            var currentX = -this._scrollList.getListMap().getCurrentTransformState().translateX;
-            var scale = this._scrollList.getListMap().getCurrentTransformState().scale;
+            var listMap = this._scrollList.getListMap();
+            var currentState = listMap.getCurrentTransformState();
+            var currentY = currentState.translateY;
+            var currentX = -currentState.translateX;
+            var currentScale = currentState.scale;
+
             if (direction === keys.LEFT) {
-                this._scrollList.scrollToPosition({ x: (currentX / scale) - 40 });
+                listMap.panTo({
+                    x: -(currentX - 40 * currentScale),
+                    y: currentY
+                });
             }
             else {
-                this._scrollList.scrollToPosition({ x: (currentX / scale) + 40 });
+                listMap.panTo({
+                    x: -(currentX + 40 * currentScale),
+                    y: currentY
+                });
             }
         },
 

--- a/test/scroll_list/KeyNavigatorSpec.js
+++ b/test/scroll_list/KeyNavigatorSpec.js
@@ -72,29 +72,33 @@ define(function(require){
             });
             
             it('should scroll left on left arrow key presses', function() {
+                var listMap = scrollList.getListMap();
                 spyOn(keyNavigator, '_moveX').andCallThrough();
-                spyOn(scrollList, 'scrollToPosition');
+                spyOn(listMap, 'panTo');
                 
-                var currentPosition = -scrollList.getListMap().getCurrentTransformState().translateX;
+                var currentX = -scrollList.getListMap().getCurrentTransformState().translateX;
+                var currentY = -scrollList.getListMap().getCurrentTransformState().translateY;
                 var currentScale = scrollList.getListMap().getCurrentTransformState().scale;
                 var keyboardEvent = createEvent(false, 37);
                 keyNavigator._keyNavListener(keyboardEvent);
                 
                 expect(keyNavigator._moveX).toHaveBeenCalled();
-                expect(scrollList.scrollToPosition).toHaveBeenCalledWith({ x: (currentPosition / currentScale) - 40 });
+                expect(listMap.panTo).toHaveBeenCalledWith({ x: -(currentX - 40 * currentScale), y: -currentY });
             });
             
             it('should scroll right on right arrow key presses', function() {
+                var listMap = scrollList.getListMap();
                 spyOn(keyNavigator, '_moveX').andCallThrough();
-                spyOn(scrollList, 'scrollToPosition');
+                spyOn(listMap, 'panTo');
                 
-                var currentPosition = -scrollList.getListMap().getCurrentTransformState().translateX;
+                var currentX = -scrollList.getListMap().getCurrentTransformState().translateX;
+                var currentY = -scrollList.getListMap().getCurrentTransformState().translateY;
                 var currentScale = scrollList.getListMap().getCurrentTransformState().scale;
                 var keyboardEvent = createEvent(false, 39);
                 keyNavigator._keyNavListener(keyboardEvent);
                 
                 expect(keyNavigator._moveX).toHaveBeenCalled();
-                expect(scrollList.scrollToPosition).toHaveBeenCalledWith({ x: (currentPosition / currentScale) + 40 });
+                expect(listMap.panTo).toHaveBeenCalledWith({ x: -(currentX + 40 * currentScale), y: -currentY });
             });
             
             it('should go down a page on page down key presses', function() {


### PR DESCRIPTION
When the ScrollList is not on the first page, and there is nowhere on the left to be scrolled to, if the left arrow key is pressed the page number will change to 1 and the viewer will show an area outside the canvas. http://screencast.com/t/uMBJk4qf

Solution:
Stop using `ScrollToPosition` for horizontal panning. It works beautifully for vertical scrolling, but produces some strange behavior that I was not able to untangle when trying to do horizontal panning -  it seems to decide that the area we're interested in scrolling to is not already rendered (although with horizontal scrolling, it always is), and then renders the wrong section of the document.
## **Tests**

Commit ac956fb adds a unit test that checks for the bug - after a left or right arrow keypress, the `ScrollList` should NOT be on a different page than it was previously. The test fails in commit  ac956fb, and passes after commit 1fbf7b9 (noted here since CI builds aren't working).
## **How To +10/QA**

``` bash
# skip the following steps if you've already initialized the project
$ git clone git@github.com:WebFilings/wf-uicomponents.git
$ cd wf-uicomponents

# do not skip these!
$ git fetch && 
git checkout HY-1093 && 
./init.sh && 
grunt qa
```
- Open the ScrollList Demo
- Zoom in and scroll left and right.
- The page number in the bottom right corner should NOT change when the right/left arrow keys are pressed
- Scroll a ways down and press the right and left arrow keys. The ScrollList should still be rendered in the right place, not blank.
- All tests should pass.

---

Please review: @timmccall-wf @patkujawa-wf 
