### PR TITLE
Center ScrollLists Vertically

### DIFF
--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -170,9 +170,12 @@ define(function(require) {
             });
 
             // Set initial transform in order to center the content.
+            var viewportSize = layout.getViewportSize();
+            var layoutSize = layout.getSize();
             map.transform({
-                x: (layout.getViewportSize().width - layout.getSize().width) / 2,
-                y: 0,
+                x: (viewportSize.width - layoutSize.width) / 2,
+                y: (viewportSize.height < layoutSize.height ? 0 :
+                    (viewportSize.height - layoutSize.height) / 2),
                 scale: 1
             });
 

--- a/test/scroll_list/AwesomeMapFactorySpec.js
+++ b/test/scroll_list/AwesomeMapFactorySpec.js
@@ -46,6 +46,56 @@ define(function(require) {
                         }]);
                 });
             });
+
+            describe('initial positioning', function() {
+                function createMap(listWidth, listHeight) {
+                    var itemSizeCollection = new ItemSizeCollection({
+                        maxWidth: listWidth,
+                        maxHeight: listHeight,
+                        items: [{ width: listWidth, height: listHeight }]
+                    });
+
+                    // setup scroll list
+                    var scrollList = new ScrollList($host[0], itemSizeCollection);
+
+                    // Setup list map.
+                    return AwesomeMapFactory.createListMap(scrollList);
+                }
+
+                it('should center scrollList vertically in viewport when scrollList ' +
+                    'height is less than viewport height', function() {
+                    // Setup list map
+                    var map = createMap(75, 100);
+
+                    // Expect the map to be centered vertically in the viewport when created
+                    var mapTopWhenCentered = (400 - 100) / 2;
+                    expect(map.getTranslation().y).toEqual(mapTopWhenCentered);
+                });
+                it('should center scrollList horizontally in viewport when scrollList ' +
+                    'width is less than viewport width', function() {
+                    // Setup list map
+                    var map = createMap(100, 75);
+
+                    // Expect the map to be centered horizontally in the viewport when created
+                    var mapLeftWhenCentered = (400 - 100) / 2;
+                    expect(map.getTranslation().x).toEqual(mapLeftWhenCentered);
+                });
+                it('should position the scrollList at the top of the viewport when ' +
+                    'scrollList height is greater than viewport height', function() {
+                    var map = createMap(75, 500);
+
+                    // Expect the map to be positioned at the top of the viewport
+                    expect(map.getTranslation().y).toEqual(0);
+                });
+                it('should position the scrollList at the left edge of the viewport when ' +
+                    'scrollList width is greater than viewport width', function() {
+                    // Setup list map
+                    var map = createMap(500, 75);
+
+                    // Expect the map to be positioned at the left of the viewport
+                    expect(map.getTranslation().x).toEqual(0);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
When a scrollList is initially created, if its vertical height is less than
the height of the viewport make sure it is centered vertically in the viewport.
## How To +10/QA:
- Travis CI Build Passes
- Run `./init.sh && grunt qa`
- Open the scrollList demo
- Resize the window so that the first item fits fully within the viewport
- Set the number of pages to 1
- Should see that the first page is centered vertically in the viewport
- Checkout master to compare behavior

@timmccall-wf @lancefisher-wf @robbecker-wf @patkujawa-wf 
