### PR TITLE
Change Peek Threshold to 1/3rd of Viewport

### DIFF
--- a/src/scroll_list/PeekInterceptor.js
+++ b/src/scroll_list/PeekInterceptor.js
@@ -263,7 +263,7 @@ define(function(require) {
             else {
                 var peekDelta = this._peekDelta;
                 var viewportHeight = layout.getViewportSize().height;
-                if (Math.abs(peekDelta) > viewportHeight / 2) {
+                if (Math.abs(peekDelta) > viewportHeight / 3) {
                     itemIndex += peekDelta > 0 ? -1 : 1;
                 }
             }

--- a/test/scroll_list/PeekInterceptorSpec.js
+++ b/test/scroll_list/PeekInterceptorSpec.js
@@ -498,7 +498,7 @@ define(function(require) {
                 var threshold;
 
                 beforeEach(function() {
-                    threshold = viewportDimensions.height / 2;
+                    threshold = viewportDimensions.height / 3;
                     listState.translateY = -500;
 
                     spyOn(scrollList, 'scrollToItem');
@@ -533,15 +533,15 @@ define(function(require) {
                     expect(scrollList.scrollToItem).not.toHaveBeenCalled();
                 });
 
-                it('should jump to previous item when peeking beyond middle of viewport', function() {
+                it('should jump to previous item when peeking beyond 1/3rd of viewport', function() {
                     shouldJumpToIndex(threshold + 1, 3);
                 });
 
-                it('should jump to next item when peeking beyond beyond middle of viewport', function() {
+                it('should jump to next item when peeking beyond 1/3rd of viewport', function() {
                     shouldJumpToIndex(-(threshold + 1), 5);
                 });
 
-                it('should jump to current item when peek does not exceed middle of viewport', function() {
+                it('should jump to current item when peek does not exceed 1/3rd of viewport', function() {
                     shouldJumpToIndex(threshold - 1, 4);
                 });
             });


### PR DESCRIPTION
## Problem

Currently the previous/next item is scrolled into view when peeking beyond 1/2 the height of the viewport. This is too much.
## Solution

Change this to threshold to 1/3rd of the viewport height.
## Unit Tests

Modified existing tests.
## How To +10/QA
- Ensure Travis CI passes.
- `grunt qa`
- Open ScrollList demo
- Change to `peek` mode
- Drag the list so that you are peeking 1/3rd of the way into an adjacent item.
- On release, should see the adjacent item scroll into view.
- Drag so that you are not peeking more than 1/3rd of the way into an adjacent item.
- On release, should see the current item snap back to the default position in the viewport.

@lancefisher-wf @robbecker-wf @patkujawa-wf @georgelesica-wf @tomconnell-wf @todbachman-wf 
