### PR TITLE
Set CSS top for the placeholder contentContainer

### DIFF
--- a/src/scroll_list/PlaceholderRenderer.js
+++ b/src/scroll_list/PlaceholderRenderer.js
@@ -225,7 +225,7 @@ define(function(require) {
                 // Remove positional styles from the content container and append to map.
                 var contentContainer = placeholder.contentContainer;
                 contentContainer.style.top = '0px';
-                contentContainer.style.left = null;
+                contentContainer.style.left = '0px';
                 itemMap.appendContent(contentContainer);
             }
         },

--- a/test/scroll_list/PlaceholderRendererSpec.js
+++ b/test/scroll_list/PlaceholderRendererSpec.js
@@ -171,8 +171,8 @@ define(function(require) {
 
                     renderer.appendPlaceholderToScrollList(itemLayout, placeholder);
 
-                    expect(placeholder.contentContainer.style.top).toBe('');
-                    expect(placeholder.contentContainer.style.left).toBe('');
+                    expect(placeholder.contentContainer.style.top).toBe('0px');
+                    expect(placeholder.contentContainer.style.left).toBe('0px');
                 });
 
                 it('should append the content container to the item map', function() {


### PR DESCRIPTION
# Problem

The content container would disappear off the viewport if the top was not set
# Solution

Set CSS top for the placeholder contentContainer
# How to test
- Checkout this branch
- `./init.sh && grunt qa` tests should pass
- your browser should open localhost:9000
- click the scrollList demo
- inspect the DOM and find the element with class `scrollList-contentContainer`
- That element should have a top and left 0px CSS property
  ![image](https://cloud.githubusercontent.com/assets/6053699/3807299/84506380-1c63-11e4-9d70-b570b9b7982d.png)
# Unit test
- updated to check for 0px

@timmccall-wf @patkujawa-wf @georgelesica-wf @tomconnell-wf @todbachman-wf 
