### PR TITLE
Fix Broken Zooming in IE9

### DIFF
--- a/src/awesome_map/TransformUtil.js
+++ b/src/awesome_map/TransformUtil.js
@@ -260,7 +260,12 @@ define(function(require) {
          * @method
          */
         clearTransformationOrigin: function(target) {
-            target.style[BrowserInfo.cssTransformOriginProperty] = '0px 0px 0px';
+            if (BrowserInfo.hasCssTransforms3d) {
+                target.style[BrowserInfo.cssTransformOriginProperty] = '0px 0px 0px';
+            }
+            else {
+                target.style[BrowserInfo.cssTransformOriginProperty] = '0px 0px';
+            }
         },
 
         /**

--- a/test/awesome_map/TransformUtilSpec.js
+++ b/test/awesome_map/TransformUtilSpec.js
@@ -269,18 +269,8 @@ define(function(require) {
 
         describe('applying transforms', function() {
 
-            var originalHasCssTransforms3d;
-
-            beforeEach(function() {
-                originalHasCssTransforms3d = BrowserInfo.hasCssTransforms3d;
-            });
-
-            afterEach(function() {
-                BrowserInfo.hasCssTransforms3d = originalHasCssTransforms3d;
-            });
-
             it('should use a 3d transform if available', function() {
-                if (BrowserInfo.hasCssTransforms3d || (BrowserInfo.hasCssTransforms3d = true)) {
+                if (BrowserInfo.hasCssTransforms3d) {
                     TransformUtil.applyTransform(target, targetState);
 
                     expect(target.style[transformProp])
@@ -289,7 +279,7 @@ define(function(require) {
             });
 
             it('should use a 2d transform if 3d is not available', function() {
-                if (!BrowserInfo.hasCssTransforms3d || !(BrowserInfo.hasCssTransforms3d = false)) {
+                if (!BrowserInfo.hasCssTransforms3d) {
                     TransformUtil.applyTransform(target, targetState);
 
                     expect(target.style[transformProp])
@@ -317,11 +307,20 @@ define(function(require) {
 
         describe('clearing transform origins', function() {
 
-            it('should zero the transformation origin of the target', function() {
-                TransformUtil.clearTransformationOrigin(target);
+            it('should use 3 values if 3d transform if available', function() {
+                if (BrowserInfo.hasCssTransforms3d) {
+                    TransformUtil.clearTransformationOrigin(target);
 
-                // IE 9 will return '', all others will return '0px 0px 0px'.
-                expect(target.style[originProp]).toMatch(/^$|^0px 0px 0px$/);
+                    expect(target.style[originProp]).toBe('0px 0px 0px');
+                }
+            });
+
+            it('should use 2 values if 3d transform is not available', function() {
+                if (!BrowserInfo.hasCssTransforms3d) {
+                    TransformUtil.clearTransformationOrigin(target);
+
+                    expect(target.style[originProp]).toBe('0px 0px');
+                }
             });
         });
 

--- a/test/scroll_list/PlaceholderRendererSpec.js
+++ b/test/scroll_list/PlaceholderRendererSpec.js
@@ -511,12 +511,12 @@ define(function(require) {
             });
 
             it('should accelerate placeholder if css 3d tranforms are available', function() {
-                BrowserInfo.hasCssTransforms3d = true;
+                if (BrowserInfo.hasCssTransforms3d) {
+                    renderer.render(itemLayout);
 
-                renderer.render(itemLayout);
-
-                var placeholder = renderer.get(0).element;
-                expect(placeholder.style[BrowserInfo.cssTransformProperty]).toBe('translateZ(0px)');
+                    var placeholder = renderer.get(0).element;
+                    expect(placeholder.style[BrowserInfo.cssTransformProperty]).toBe('translateZ(0px)');
+                }
             });
 
             it('should not accelerate placeholder if css 3d tranforms are available', function() {


### PR DESCRIPTION
## Problem

Setting 3 values for `transform-origin` prop caused IE9 to ignore.
## Solution

Set 2 values in browsers that do not support 3d transforms.
## Unit Tests

Added and modified. Browser-specific tests will only run in browsers that support the required context. Faking requires introducing uncertainty into expectations.
## How To +10/QA
- Travis CI should pass.
- `gunt test`
- Run the HTML spec runner in IE9. No whammies.

@lancefisher-wf @robbecker-wf @patkujawa-wf @georgelesica-wf @tomconnell-wf @todbachman-wf 
