### PR TITLE
Fix Peek Mode While Dragging

### DIFF
--- a/examples/scroll_list/scroll-list.js
+++ b/examples/scroll_list/scroll-list.js
@@ -236,8 +236,9 @@ define(function(require) {
         });
 
         $('#jumpToPage').submit(function() {
-            scrollList.scrollTo({
-                index: this.elements.page.value - 1
+            scrollList.scrollToItem({
+                index: this.elements.page.value - 1,
+                offset: { y: 0 }
             });
             $(':focus').blur();
             return false;

--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -64,13 +64,19 @@ define(function(require) {
 
             // Register interceptors.
             map.addInterceptor(new DoubleTapZoomInterceptor());
+            if (options.scaleLimits) {
+                map.addInterceptor(new ScaleInterceptor(options.scaleLimits));
+            }
+            if (options.mode === ScrollModes.PEEK) {
+                map.addInterceptor(new PeekInterceptor(scrollList));
+            }
+            else if (options.mode === ScrollModes.SINGLE) {
+                map.addInterceptor(new SwipeNavigationInterceptor(scrollList));
+            }
             map.addInterceptor(new SwipeInterceptor({
                 animationDuration: 250,
                 constrainToAxes: true
             }));
-            if (options.scaleLimits) {
-                map.addInterceptor(new ScaleInterceptor(options.scaleLimits));
-            }
             map.addInterceptor(new BoundaryInterceptor({
                 centerContent: true,
                 mode: 'stop'
@@ -121,12 +127,6 @@ define(function(require) {
                 }));
             }
             else {
-                if (options.mode === ScrollModes.PEEK) {
-                    map.addInterceptor(new PeekInterceptor(scrollList));
-                }
-                else { // Modes.SINGLE
-                    map.addInterceptor(new SwipeNavigationInterceptor(scrollList));
-                }
                 map.addInterceptor(new MouseWheelNavigationInterceptor(scrollList));
                 map.addInterceptor(new StopPropagationInterceptor(scrollList));
             }

--- a/src/scroll_list/PeekInterceptor.js
+++ b/src/scroll_list/PeekInterceptor.js
@@ -154,7 +154,7 @@ define(function(require) {
             var contentBottom = contentState.translateY +
                                 Math.floor(contentHeight * contentState.scale);
 
-            var listMap = this._awesomeMap;
+            var listMap = this._scrollList.getListMap();
             var listState = listMap.getCurrentTransformState();
             var listHeight = listMap.getContentDimensions().height;
             var listTop = listState.translateY;
@@ -315,7 +315,8 @@ define(function(require) {
          * crossing the center of the viewport.
          */
         _setPeekDeltaByCurrentPosition: function() {
-            var currentState = this._awesomeMap.getCurrentTransformState();
+            var listMap = this._scrollList.getListMap();
+            var currentState = listMap.getCurrentTransformState();
             var viewportTop = -currentState.translateY / currentState.scale;
 
             var layout = this._scrollList.getLayout();

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -646,7 +646,7 @@ define(function(require) {
          *   The anchor location is constrained by any viewing boundaries that exist
          *   in the document or viewing mode.
          * @param {{ x: number, y: number}} [options.offset={ x: 0, y: 0 }]
-         *   An item-relative offset to position the viewport.  Positive numbers
+         *   An item-relative offset to position the viewport. Positive numbers
          *   move the viewport to the left and down for x and y, respectively.
          *   Negative numbers do the reverse.
          * @param {Function} [options.done] - Callback invoked when the jump is complete.
@@ -678,10 +678,6 @@ define(function(require) {
             if (options.index === undefined) {
                 throw new Error('ScrollList#scrollToItem: index is required.');
             }
-            options.viewportAnchorLocation = options.viewportAnchorLocation || 'top';
-            options.offset = options.offset || { x: 0, y: 0 };
-            options.offset.x = options.offset.x || 0;
-            options.offset.y = options.offset.y || 0;
 
             var panToOptions = {
                 x: 0,
@@ -727,11 +723,16 @@ define(function(require) {
 
             // If given a content offset within the item, adjust the panToOptions.
             if (options.offset) {
+                var viewportAnchorLocation = options.viewportAnchorLocation || 'top';
+                var offset = options.offset || { x: 0, y: 0 };
+                offset.x = offset.x || 0;
+                offset.y = offset.y || 0;
+
                 this._applyItemOffset(
                     panToOptions,
-                    options.offset,
+                    offset,
                     itemLayout.scaleToFit,
-                    options.viewportAnchorLocation
+                    viewportAnchorLocation
                 );
             }
 

--- a/test/scroll_list/PeekInterceptorSpec.js
+++ b/test/scroll_list/PeekInterceptorSpec.js
@@ -48,12 +48,13 @@ define(function(require) {
         beforeEach(function() {
             listMapPlane = document.createElement('div');
 
-            listMap.onInteraction = function() {};
+            itemMap.onInteraction = function() {};
 
             listDimensions = { height: 1000 };
             viewportDimensions = { height: 200 };
             itemDimensions = { height: 200 };
 
+            spyOn(scrollList, 'getListMap').andReturn(listMap);
             spyOn(scrollList, 'getCurrentItemMap').andReturn(itemMap);
             spyOn(scrollList, 'getLayout').andReturn(layout);
             spyOn(listMap, 'getTransformationPlane').andReturn(listMapPlane);
@@ -62,7 +63,7 @@ define(function(require) {
             spyOn(itemMap, 'getContentDimensions').andReturn(itemDimensions);
 
             interceptor = new PeekInterceptor(scrollList);
-            interceptor.register(listMap);
+            interceptor.register(itemMap);
         });
 
         it('should be mixed with InterceptorMixin', function() {


### PR DESCRIPTION
## Problem

Peek mode handling was broken due to events targeting the item map before the list map after removing the ScrollList hit area.
## Solution

Put the peek interceptor on the item maps instead of the list map.
## Unit Tests

Modified
## How To +10/QA
- Travis CI build should pass.
- `grunt serve`
- Navigate to the ScrollList demo.
- Set the fit mode to `width` and the scroll mode to `peek`.
- Grab the first item in the list and drag it up and down over and over at different speeds. Drag it enough to reveal the second item in the list.
- _Should see smooth dragging behavior without the content jumping._
- _Should see first item snap back to bottom of viewport if releasing while peeking less than 1/3rd the viewport height._
- _Should not see any inconsistency in the gap height between the first and second item._

@lancefisher-wf @robbecker-wf @patkujawa-wf @georgelesica-wf @tomconnell-wf @todbachman-wf  
