### PR TITLE
Clear Content From AwesomeMaps During ScrollList Refresh

### DIFF
--- a/src/scroll_list/PlaceholderRenderer.js
+++ b/src/scroll_list/PlaceholderRenderer.js
@@ -299,9 +299,10 @@ define(function(require) {
                 allPlaceholders.push(activePlaceholders[itemIndex]);
             });
 
-            // Invalidate the viewport dimensions for each item map.
+            // Reinitialize each item map.
             allPlaceholders.forEach(function(placeholder) {
                 if (placeholder.map) {
+                    placeholder.map.clearContent();
                     placeholder.map.invalidateViewportDimensions();
                 }
             });

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -607,6 +607,7 @@ define(function(require) {
             this._layout.clear();
             this._layout.measure();
             this._renderer.refresh();
+            listMap.clearContent();
             listMap.invalidateViewportDimensions();
             listMap.setContentDimensions(this._layout.getSize());
 

--- a/test/scroll_list/PlaceholderRendererSpec.js
+++ b/test/scroll_list/PlaceholderRendererSpec.js
@@ -350,27 +350,40 @@ define(function(require) {
                 spyOn(renderer, 'appendPlaceholderToScrollList');
                 renderer.render(new ItemLayout({ itemIndex: 0 }));
 
+                spyOn(itemMap, 'clearContent');
                 spyOn(itemMap, 'invalidateViewportDimensions');
             });
 
-            it('should invalidate the viewport dimensions for active item maps', function() {
-                // Attach the fake map to the placheolder.
-                renderer.get(0).map = itemMap;
+            describe('active item maps', function() {
+                beforeEach(function() {
+                    // Attach the fake map to the placheolder.
+                    renderer.get(0).map = itemMap;
 
-                renderer.refresh();
-
-                expect(itemMap.invalidateViewportDimensions).toHaveBeenCalled();
+                    renderer.refresh();
+                });
+                it('should clear the content from the map', function() {
+                    expect(itemMap.clearContent).toHaveBeenCalled();
+                });
+                it('should invalidate the viewport dimensions for the map', function() {
+                    expect(itemMap.clearContent).toHaveBeenCalled();
+                });
             });
 
-            it('should invalidate the viewport dimensions for pooled item maps', function() {
-                // Put the placeholder in the pool, then attach the fake map.
-                var placeholder = renderer.get(0);
-                renderer.remove(0);
-                placeholder.map = itemMap;
+            describe('pooled item maps', function() {
+                beforeEach(function() {
+                    // Put the placeholder in the pool, then attach the fake map.
+                    var placeholder = renderer.get(0);
+                    renderer.remove(0);
+                    placeholder.map = itemMap;
 
-                renderer.refresh();
-
-                expect(itemMap.invalidateViewportDimensions).toHaveBeenCalled();
+                    renderer.refresh();
+                });
+                it('should clear the content from the map', function() {
+                    expect(itemMap.clearContent).toHaveBeenCalled();
+                });
+                it('should invalidate the viewport dimensions for the map', function() {
+                    expect(itemMap.clearContent).toHaveBeenCalled();
+                });
             });
         });
 

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -450,6 +450,17 @@ define(function(require) {
                 });
             });
 
+            it('should clear the list map content', function() {
+                testScrollList(function(scrollList) {
+                    var map = scrollList.getListMap();
+
+                    spyOn(map, 'clearContent');
+                    scrollList.refresh();
+
+                    expect(map.clearContent).toHaveBeenCalled();
+                });
+            });
+
             it('should invalidate the list map viewport dimensions', function() {
                 testScrollList(function(scrollList) {
                     var map = scrollList.getListMap();


### PR DESCRIPTION
## Problem

Stale content was lingering in the DOM after refreshing the ScrollList.
## Solution

Ensure the content is cleared.
## Unit Tests

Added
## How To +10/QA
- Travis CI should pass.

@lancefisher-wf @robbecker-wf @patkujawa-wf @georgelesica-wf @tomconnell-wf @todbachman-wf 
