### PR TITLE
Use jasmine.async lib to simplify async tests

### DIFF
--- a/src/AsyncSpec.js
+++ b/src/AsyncSpec.js
@@ -11,8 +11,9 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-define(function() {
+define([], function() {
     'use strict';
+    /* global it, runs, waitsFor */
 
     function runAsync(block) {
         return function() {
@@ -44,7 +45,6 @@ define(function() {
     };
 
     AsyncSpec.prototype.it = function(description, block) {
-        /* global it */
         // For some reason, `it` is not attached to the current
         // test suite, so it has to be called from the global
         // context.

--- a/test/jasmine.async.js
+++ b/test/jasmine.async.js
@@ -1,0 +1,55 @@
+/**
+https://github.com/derickbailey/jasmine.async
+(MIT License)
+
+Copyright ©2012 Muted Solutions, LLC. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+define(function() {
+    'use strict';
+
+    function runAsync(block) {
+        return function() {
+            var done = false;
+            var complete = function() {
+                done = true;
+            };
+
+            runs(function() {
+                block(complete);
+            });
+
+            waitsFor(function() {
+                return done;
+            });
+        };
+    }
+
+    function AsyncSpec(spec) {
+        this.spec = spec;
+    }
+
+    AsyncSpec.prototype.beforeEach = function(block) {
+        this.spec.beforeEach(runAsync(block));
+    };
+
+    AsyncSpec.prototype.afterEach = function(block) {
+        this.spec.afterEach(runAsync(block));
+    };
+
+    AsyncSpec.prototype.it = function(description, block) {
+        /* global it */
+        // For some reason, `it` is not attached to the current
+        // test suite, so it has to be called from the global
+        // context.
+        it(description, runAsync(block));
+    };
+
+    return AsyncSpec;
+});

--- a/test/scroll_list/ViewportResizeInterceptorSpec.js
+++ b/test/scroll_list/ViewportResizeInterceptorSpec.js
@@ -18,6 +18,7 @@ define(function(require) {
     'use strict';
 
     var $ = require('jquery');
+    var AsyncSpec = require('../jasmine.async');
     var AwesomeMap = require('wf-js-uicomponents/awesome_map/AwesomeMap');
     var EventTypes = require('wf-js-uicomponents/awesome_map/EventTypes');
     var Gesture = require('wf-js-uicomponents/awesome_map/Gesture');
@@ -25,6 +26,7 @@ define(function(require) {
     var ViewportResizeInterceptor = require('wf-js-uicomponents/scroll_list/ViewportResizeInterceptor');
 
     describe('ViewportResizeInterceptor', function() {
+        var async = new AsyncSpec(this);
         var $host = $('<div>').css({ position: 'absolute', top: -10000, width: 400, height: 400 });
         var fakeScrollList = {
             refresh: function() {}
@@ -55,7 +57,7 @@ define(function(require) {
             expect(result).toBe(false);
         });
 
-        it('should refresh the scroll list 100ms after the last resize event', function() {
+        async.it('should refresh the scroll list 100ms after the last resize event', function(done) {
             var gesture = new Gesture();
             var event = new InteractionEvent(EventTypes.RESIZE, gesture, gesture);
 
@@ -64,11 +66,10 @@ define(function(require) {
 
             expect(fakeScrollList.refresh).not.toHaveBeenCalled();
 
-            waits(100);
-
-            runs(function() {
+            setTimeout(function() {
                 expect(fakeScrollList.refresh).toHaveBeenCalled();
-            });
+                done();
+            }, 100);
         });
     });
 });

--- a/test/scroll_list/ViewportResizeInterceptorSpec.js
+++ b/test/scroll_list/ViewportResizeInterceptorSpec.js
@@ -18,7 +18,7 @@ define(function(require) {
     'use strict';
 
     var $ = require('jquery');
-    var AsyncSpec = require('../jasmine.async');
+    var AsyncSpec = require('wf-js-uicomponents/AsyncSpec');
     var AwesomeMap = require('wf-js-uicomponents/awesome_map/AwesomeMap');
     var EventTypes = require('wf-js-uicomponents/awesome_map/EventTypes');
     var Gesture = require('wf-js-uicomponents/awesome_map/Gesture');


### PR DESCRIPTION
Problem: Jasmine 2 changed the way async tests are written in favor of a `done` callback (as mocha does), deprecating the previous `runs/waitsFor` paradigm. Until all tests are migrated to this new paradigm, we can't use jasmine 2.

Solution: Use [derickbailey/jasmine.async](https://github.com/derickbailey/jasmine.async)'s AsyncSpec to get the `done` callback style while still running jasmine 1.x. When all specs are migrated this way, upgrading to jasmine 2 should be as simple as `s/async\.(it|beforeEach|afterEach)/\1/` (and then removing the unused AsyncSpec stuff). (Ok, not quite that easy - other changes are with stubbing, e.g. `spyOn(window, 'setInterval).andCallThrough() -> spyOn(window, 'setInterval').and.callThrough()`, using a fake clock, and custom matchers - see [Jochen Preusche : How to switch from jasmine 1.3.x to jasmine 2.0.0](https://coderwall.com/p/a_sd-a).)

Only one spec was migrated for now, but more will come! :)
