### PR TITLE
Fix padding issue to correct the wiggle.

### DIFF
--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -897,12 +897,14 @@ define(function(require) {
                 totalHeight = layout.bottom;
             }
 
-            // Ensure when in flow mode, where items are scaled together,
-            // that the layout size accommodates the maximum possible item width.
+            // Ensure when in flow mode, where items are scaled together, that
+            // the layout size accommodates the maximum possible item width.
             // If this is not done, then positioning will change and shift if
-            // newer, wider items are added dynamically.
+            // newer, wider items are added dynamically. At the same time, do
+            // not scale the padding as it is expected to be independent of the
+            // scale applied to the document.
             if (flow) {
-                maxWidth = (itemSizeCollection.maxWidth + 2 * padding) * cachedScaleToFit;
+                maxWidth = itemSizeCollection.maxWidth * cachedScaleToFit + (2 * padding);
             }
 
             // Cache the item layouts and total layout size.

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -712,8 +712,9 @@ define(function(require) {
                     it('should fit the maximum size of items to the viewport', function() {
                         var viewportSize;
                         var padding;
+                        var mockScale = 0.5;
 
-                        spyOn(ScaleStrategies, 'auto').andReturn(0.5);
+                        spyOn(ScaleStrategies, 'auto').andReturn(mockScale);
 
                         layout = createVerticalLayout({ flow: true, fit: 'auto' });
                         viewportSize = layout.getViewportSize();
@@ -730,10 +731,23 @@ define(function(require) {
                         expect(scaleArgs[2]).toBe(padding);
 
                         layout.getItemLayouts().forEach(function(item, index) {
-                            expect(item.scaleToFit).toBe(0.5);
+                            expect(item.scaleToFit).toBe(mockScale);
                             expect(item.width).toBe(itemMetadata[index].width / 2);
                             expect(item.height).toBe(itemMetadata[index].height / 2);
                         });
+                    });
+
+                    it('should correctly account for left and right padding', function() {
+                        var padding = 20;
+                        var mockScale = 0.5;
+
+                        spyOn(ScaleStrategies, 'auto').andReturn(mockScale);
+
+                        layout = createVerticalLayout({ flow: true, fit: 'auto', padding: padding });
+                        var layoutSize = layout.getSize();
+
+                        // 90 = max page width * scale + 2 * padding
+                        expect(layoutSize.width).toEqual(90);
                     });
 
                     it('should set top to the cumulative outer height', function() {


### PR DESCRIPTION
## Problem

Content would "wiggle" left-right in flow mode when fit to width.
## Solution

Padding was being scaled, making the DOM elements too wide when the scale-to-fit value was >1. Don't do that.
## Tests

Added.
## QA

Open the scroll list demo, make the browser window as wide as possible, set the fit mode to "width". You shouldn't be able to scroll left-right at all by default (un-zoomed).
