### PR TITLE
add CSS will-change: transform to the transformation plane (HY-1710)

### DIFF
--- a/src/awesome_map/AwesomeMap.js
+++ b/src/awesome_map/AwesomeMap.js
@@ -845,6 +845,7 @@ define(function(require) {
             this._transformationPlane = document.createElement('div');
             this._transformationPlane.className = 'awesomeMap-transformationPlane';
             this._transformationPlane.style.position = 'absolute';
+            this._transformationPlane.style.willChange = 'transform';
             TransformUtil.clearTransformationOrigin(this._transformationPlane);
 
             // Add the elements to the DOM

--- a/test/awesome_map/AwesomeMapSpec.js
+++ b/test/awesome_map/AwesomeMapSpec.js
@@ -118,6 +118,7 @@ define(function(require) {
 
                 expect(transformationPlane).not.toBeNull();
                 expect(transformationPlane.style.position).toBe('absolute');
+                expect(transformationPlane.style.willChange).toBe('transform');
                 expect(transformationPlane.style.top).toBe('');
                 expect(transformationPlane.style.bottom).toBe('');
                 expect(transformationPlane.style.left).toBe('');


### PR DESCRIPTION
# Problem

Scrolling performance takes a serious hit in Chrome 39+ due to the translateZ hack no longer working.
# Solution

Tell the browser we really want a GPU layer by adding CSS will-change: transform to the transformation plane
# Testing
- Confirm poor scrolling performance with a large list of items in Chrome 39+ (Canary 41 is easy to install side by side)
- Using this PR branch, confirm that the div#awesomeMap-transformationPlane has a style of `will-change: transform`
- Confirm scrolling performance is back to being awesome
