### PR TITLE
HY-1737 Allow Consumer to Refresh ScrollBars to Trigger Redraw

### DIFF
--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -924,7 +924,9 @@ define(function(require) {
             // not scale the padding as it is expected to be independent of the
             // scale applied to the document.
             if (flow) {
-                maxWidth = itemSizeCollection.maxWidth * cachedScales.default + (2 * padding);
+                maxWidth = Math.floor(
+                    itemSizeCollection.maxWidth * cachedScales.default + (2 * padding)
+                );
             }
 
             // Cache the item layouts and total layout size.

--- a/src/scroll_bar/ScrollBar.js
+++ b/src/scroll_bar/ScrollBar.js
@@ -143,7 +143,7 @@ define(function(require) {
             } else {
                 self._extent = -offset.x;
             }
-                
+
             if (!self._scrollerScrolling && !self._disposed) {
                 self._placeScroller();
             }
@@ -279,6 +279,11 @@ define(function(require) {
             this._disposed = true;
         },
 
+        refresh: function() {
+            this._cacheDimensions();
+            this._placeScroller();
+        },
+
         //---------------------------------------------------------
         // Private methods
         //---------------------------------------------------------
@@ -315,7 +320,8 @@ define(function(require) {
         },
 
         /**
-         * Calculate the scroll bar height based on the viewport height and the scaled virtual height
+         * Calculate the scroller size based on the viewport size and
+         * the scaled content size.
          */
         _setScrollerSize: function() {
             var minSize = this._options.minSize || DEFAULT_MIN_SIZE;
@@ -354,7 +360,6 @@ define(function(require) {
 
         /**
          * Initialize the HTML elements used by this instance of ScrollBar
-         * @private
          */
         _setupDOM: function() {
             var scrollerEl = document.createElement('div');
@@ -473,7 +478,7 @@ define(function(require) {
             var transformState = this._activeMap.getCurrentTransformState();
             var contentSize = this._activeMap.getContentDimensions();
             var viewportSize = this._activeMap.getViewportDimensions();
-            
+
             this._scale = transformState.scale;
             if (this._isVertical) {
                 this._extent = -transformState.translateY;

--- a/test/scroll_bar/ScrollBarSpec.js
+++ b/test/scroll_bar/ScrollBarSpec.js
@@ -65,7 +65,7 @@ define(function(require) {
             options.trackMargin = trackMargin || 0;
 
             scrollBar = new ScrollBar(scrollList, parentEl, options);
-            
+
             // Need to trigger a render so that the scrollbar's callbacks get registered.
             scrollList.render();
         }
@@ -512,6 +512,25 @@ define(function(require) {
                 it('should hide the scrollbar when all content visible', function() {
                     testHideOnShortContent();
                 });
+            });
+        });
+
+        describe('refreshing', function() {
+            beforeEach(function() {
+                initialize('vertical' /* doesn't matter for this suite */);
+            });
+            afterEach(function() {
+                cleanup();
+            });
+            it('cache the current dimensions calculations', function() {
+                spyOn(scrollBar, '_cacheDimensions');
+                scrollBar.refresh();
+                expect(scrollBar._cacheDimensions).toHaveBeenCalled();
+            });
+            it('should place the scroller', function() {
+                spyOn(scrollBar, '_placeScroller');
+                scrollBar.refresh();
+                expect(scrollBar._placeScroller).toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
## Problem

Need a way to force the redraw of ScrollBars when consumer resizes the ScrollList viewport.
## Solution

Add a `refresh` method.
## Unit Tests

Yes
## How To +10/QA
- Travis CI should pass
- See related tickets for +10

@todbachman-wf 
