### PR TITLE
HY-1838 Fix require.config in Examples

### DIFF
--- a/examples/require.config.js
+++ b/examples/require.config.js
@@ -1,6 +1,7 @@
 requirejs.config({
     baseUrl: './',
     paths: {
+        bowser: '../../bower_components/bowser/bowser',
         hammerjs: '../../bower_components/hammerjs/dist/hammer',
         jquery: '../../bower_components/jquery/jquery',
         lodash: '../../bower_components/lodash/dist/lodash',


### PR DESCRIPTION
Problem
-------

No require.cofig path for bowser.

Solution
--------

Add one.

Unit Tests
----------

None needed.

How To +10/QA
-------------

- `init.sh && grunt serve`
- Should be able to view the ScrollList demo, for example.

@robbecker-wf @stephenbush-wf 