### PR TITLE
HY-1826 - Set src/ as the lib directory for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
     "grunt": "^0.4.5",
     "grunt-contrib-requirejs": "~0.4.1",
     "wf-grunt": "git://github.com/WebFilings/wf-grunt.git#0.4.0"
+  },
+  "jspm": {
+    "directories": {
+      "lib": "src"
+    }
   }
 }


### PR DESCRIPTION
# Problem
Since requireJS aliases are set to allow referencing files in src/, without typing src/, jspm consumers will get 404s when attempting to use the require() functions.

# Solution
Instruct jspm, via package.json, that src/ is the lib directory.  This change allows jspm to automagically work with the existing code, and those requireJS aliases. 

# How to Test   
This is just a config change, so there is nothing to functionally test.