### PR TITLE
HV-83 Add fit mode none

### DIFF
--- a/examples/scroll_list/index.html
+++ b/examples/scroll_list/index.html
@@ -21,6 +21,7 @@
                 <option value="auto">Auto</option>
                 <option value="width">Width</option>
                 <option value="height">Height</option>
+                <option value="none">None</option>
             </select>
         </div>
     </div>

--- a/src/layouts/ScaleStrategies.js
+++ b/src/layouts/ScaleStrategies.js
@@ -86,6 +86,15 @@ define(function() {
         },
 
         /**
+         * Returns 1.0 to prevents scaling of the content displayed in the viewport
+         *
+         * @return {number}
+         */
+        none: function() {
+            return 1.0;
+        },
+
+        /**
          * Gets the scale required to fit the width of the viewport.
          *
          * @method

--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -844,7 +844,8 @@ define(function(require) {
                         default: Math.min(scale, options.fitUpscaleLimit),
                         width: ScaleStrategies.width(viewportSize, sample, padding),
                         height: ScaleStrategies.height(viewportSize, sample, padding),
-                        auto: ScaleStrategies.auto(viewportSize, sample, padding)
+                        auto: ScaleStrategies.auto(viewportSize, sample, padding),
+                        none: ScaleStrategies.none()
                     };
                     return result;
                 }

--- a/src/scroll_list/FitModes.js
+++ b/src/scroll_list/FitModes.js
@@ -20,7 +20,8 @@ define(function() {
     var FitModes = {
         AUTO: 'auto',
         WIDTH: 'width',
-        HEIGHT: 'height'
+        HEIGHT: 'height',
+        NONE: 'none'
     };
 
     return FitModes;

--- a/test/layouts/ScaleStrategiesSpec.js
+++ b/test/layouts/ScaleStrategiesSpec.js
@@ -70,5 +70,13 @@ define(function(require) {
                 expect(scale).toBeCloseTo(0.33, 2);
             });
         });
+
+        describe('when not fitting', function() {
+            it('should not scale the content', function() {
+                var scale = ScaleStrategies.none(viewportDimensions, content, contentMargin);
+
+                expect(scale).toEqual(1.0);
+            });
+        });
     });
 });

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -687,6 +687,7 @@ define(function(require) {
                     spyOn(ScaleStrategies, 'auto').andReturn(1);
                     spyOn(ScaleStrategies, 'height').andReturn(1);
                     spyOn(ScaleStrategies, 'width').andReturn(1);
+                    spyOn(ScaleStrategies, 'none').andReturn(1);
 
                     createVerticalLayout({ fit: 'auto' });
                     expect(ScaleStrategies.auto).toHaveBeenCalled();
@@ -696,20 +697,27 @@ define(function(require) {
 
                     createVerticalLayout({ fit: 'width' });
                     expect(ScaleStrategies.width).toHaveBeenCalled();
+
+                    createVerticalLayout({ fit: 'none' });
+                    expect(ScaleStrategies.none).toHaveBeenCalled();
                 });
 
                 it('should use the item-specific scale strategy if given', function() {
                     var autoScale = 0.1;
                     var heightScale = 0.2;
                     var widthScale = 0.3;
+                    var noneScale = 0.4;
+
                     spyOn(ScaleStrategies, 'auto').andReturn(autoScale);
                     spyOn(ScaleStrategies, 'height').andReturn(heightScale);
                     spyOn(ScaleStrategies, 'width').andReturn(widthScale);
+                    spyOn(ScaleStrategies, 'none').andReturn(noneScale);
 
                     var mixedFitItemMetadata = [
                         { width: 100, height: 200, fit: 'auto' },
                         { width: 100, height: 200, fit: 'height' },
                         { width: 100, height: 200, fit: 'width' },
+                        { width: 100, height: 200, fit: 'none' },
                         { width: 100, height: 200 },
                     ];
                     var itemSizeCollection = createItemSizeCollection(mixedFitItemMetadata);
@@ -719,7 +727,8 @@ define(function(require) {
                     expect(layout.getItemLayout(0).scaleToFit).toEqual(autoScale);
                     expect(layout.getItemLayout(1).scaleToFit).toEqual(heightScale);
                     expect(layout.getItemLayout(2).scaleToFit).toEqual(widthScale);
-                    expect(layout.getItemLayout(3).scaleToFit).toEqual(autoScale);
+                    expect(layout.getItemLayout(3).scaleToFit).toEqual(noneScale);
+                    expect(layout.getItemLayout(4).scaleToFit).toEqual(autoScale);
                 });
 
                 it('should apply padding to the left and right of all items', function() {


### PR DESCRIPTION
## Problem
We provide 'width', 'height', and 'auto' fit modes for the ScrollList control, but we don't currently have a way to display content at its native scale.

## Solution
Add a fit mode 'none' that doesn't scale the content when it is displayed.

## How to QA/+10
1. CI Build Passes
1. Check out the `HV-83_add_fit_none_to_scrolllist` branch
1. Run `./init.sh && grunt qa`
1. Open the scrollList demo
1. Select the 'none' fit mode
1. Confirm the content isn't fit to width or height (i.e. it is unscaled)