### PR TITLE
HY-1856: Add FitMode of ORIENTATION

### DIFF
--- a/src/layouts/Orientations.js
+++ b/src/layouts/Orientations.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2014 WebFilings, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+define(function(/*require*/) {
+    'use strict';
+
+    var Orientations = {
+        HORIZONTAL: 'horizontal',
+        VERTICAL: 'vertical'
+    };
+
+    return Orientations;
+});

--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -20,6 +20,7 @@ define(function(require) {
     var _ = require('lodash');
     var DestroyUtil = require('wf-js-common/DestroyUtil');
     var DOMUtil = require('wf-js-common/DOMUtil');
+    var FitModes = require('wf-js-uicomponents/scroll_list/FitModes');
     var ItemLayout = require('wf-js-uicomponents/layouts/ItemLayout');
     var Observable = require('wf-js-common/Observable');
     var ScaleStrategies = require('wf-js-uicomponents/layouts/ScaleStrategies');
@@ -813,6 +814,7 @@ define(function(require) {
             var viewportSize = this.getViewportSize();
             var viewportWidth = viewportSize.width;
             var viewportHeight = viewportSize.height;
+            var viewportOrientation = viewportWidth > viewportHeight ? 'landscape' : 'portrait';
 
             // Using some layout options below.
             var options = this.getOptions();
@@ -839,6 +841,27 @@ define(function(require) {
             function getScales(item) {
                 function fit(sample) {
                     var fitMode = sample.fit || options.fit;
+                    // Fit mode of ORIENTATION does not apply when scroll mode is flow.
+                    // When it does apply, it simply auto fits content when the
+                    // orientation of the viewport and content matches, otherwise
+                    // it will default to fit to width.
+                    if (fitMode === FitModes.ORIENTATION) {
+                        if (flow) {
+                            fitMode = FitModes.WIDTH;
+                        }
+                        else {
+                            var sampleOrientation = (
+                                sample.width > sample.height ?
+                                'landscape' : 'portrait'
+                            );
+                            if (viewportOrientation === sampleOrientation) {
+                                fitMode = FitModes.AUTO;
+                            }
+                            else {
+                                fitMode = FitModes.WIDTH;
+                            }
+                        }
+                    }
                     var scale = ScaleStrategies[fitMode](viewportSize, sample, padding);
                     var result = {
                         default: Math.min(scale, options.fitUpscaleLimit),

--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -23,6 +23,7 @@ define(function(require) {
     var FitModes = require('wf-js-uicomponents/scroll_list/FitModes');
     var ItemLayout = require('wf-js-uicomponents/layouts/ItemLayout');
     var Observable = require('wf-js-common/Observable');
+    var Orientations = require('wf-js-uicomponents/layouts/Orientations');
     var ScaleStrategies = require('wf-js-uicomponents/layouts/ScaleStrategies');
 
     function getDistanceToViewportCenter(itemLayout, visibleCenter) {
@@ -814,7 +815,10 @@ define(function(require) {
             var viewportSize = this.getViewportSize();
             var viewportWidth = viewportSize.width;
             var viewportHeight = viewportSize.height;
-            var viewportOrientation = viewportWidth > viewportHeight ? 'landscape' : 'portrait';
+            var viewportOrientation = (
+                viewportWidth > viewportHeight ?
+                Orientations.LANDSCAPE : Orientations.PORTRAIT
+            );
 
             // Using some layout options below.
             var options = this.getOptions();
@@ -852,7 +856,7 @@ define(function(require) {
                         else {
                             var sampleOrientation = (
                                 sample.width > sample.height ?
-                                'landscape' : 'portrait'
+                                Orientations.LANDSCAPE : Orientations.PORTRAIT
                             );
                             if (viewportOrientation === sampleOrientation) {
                                 fitMode = FitModes.AUTO;

--- a/src/scroll_list/FitModes.js
+++ b/src/scroll_list/FitModes.js
@@ -21,6 +21,7 @@ define(function() {
         AUTO: 'auto',
         WIDTH: 'width',
         HEIGHT: 'height',
+        ORIENTATION: 'orientation',
         NONE: 'none'
     };
 

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -26,7 +26,7 @@ define(function(require) {
 
     describe('VerticalLayout', function() {
 
-        var viewportSize = { width: 200, height: 500 };
+        var viewportSize;
         var $viewport = $('<div>').css({ position: 'absolute', top: -10000 });
         var itemMetadata = [];
 
@@ -54,6 +54,7 @@ define(function(require) {
 
 
         beforeEach(function() {
+            viewportSize = { width: 200, height: 500 };
             $viewport.empty().appendTo('body').css(viewportSize);
 
             itemMetadata = [
@@ -729,6 +730,50 @@ define(function(require) {
                     expect(layout.getItemLayout(2).scaleToFit).toEqual(widthScale);
                     expect(layout.getItemLayout(3).scaleToFit).toEqual(noneScale);
                     expect(layout.getItemLayout(4).scaleToFit).toEqual(autoScale);
+                });
+
+                describe('when fit mode is ORIENTATION', function() {
+                    it('should revert to fit mode of width when in flow mode', function() {
+                        var widthScale = 0.3;
+                        spyOn(ScaleStrategies, 'width').andReturn(widthScale);
+
+                        var itemMetadata = [
+                            { width: 100, height: 200 }
+                        ];
+                        var itemSizeCollection = createItemSizeCollection(itemMetadata);
+                        var options = { flow: true, fit: 'orientation' };
+                        layout = new VerticalLayout($viewport[0], itemSizeCollection, renderer, options);
+
+                        expect(layout.getItemLayout(0).scaleToFit).toEqual(widthScale);
+                    });
+                    it('should use auto fit mode if item and viewport are in same orientation', function() {
+                        var autoScale = 0.3;
+                        spyOn(ScaleStrategies, 'auto').andReturn(autoScale);
+
+                        viewportSize = { width: 100, height: 200 };
+                        var itemMetadata = [
+                            { width: 100, height: 200 }
+                        ];
+                        var itemSizeCollection = createItemSizeCollection(itemMetadata);
+                        var options = { flow: false, fit: 'orientation' };
+                        layout = new VerticalLayout($viewport[0], itemSizeCollection, renderer, options);
+
+                        expect(layout.getItemLayout(0).scaleToFit).toEqual(autoScale);
+                    });
+                    it('should use width fit mode if item and viewport are in different orientation', function() {
+                        var widthScale = 0.3;
+                        spyOn(ScaleStrategies, 'auto').andReturn(widthScale);
+
+                        viewportSize = { width: 200, height: 100 };
+                        var itemMetadata = [
+                            { width: 100, height: 200 }
+                        ];
+                        var itemSizeCollection = createItemSizeCollection(itemMetadata);
+                        var options = { flow: false, fit: 'orientation' };
+                        layout = new VerticalLayout($viewport[0], itemSizeCollection, renderer, options);
+
+                        expect(layout.getItemLayout(0).scaleToFit).toEqual(widthScale);
+                    });
                 });
 
                 it('should apply padding to the left and right of all items', function() {


### PR DESCRIPTION
Problem
-------

Consumers need to be able to change fit mode on mobile devices depending on the orientation of the viewport. 

Solution
--------

This simple solution adds a new fit mode called `ORIENTATION` which will:
- only apply in peek and single scroll modes
- apply an `auto` fit if the orientation of the viewport and item match
- apply a `width` fit if the orientations differ 

Unit Tests
----------

Added

How To +10/QA
-------------

- Verify within a consuming application

@shanesizer-wf @brentarndorfer-wf @todbachman-wf 