### PR TITLE
WARP-729: Android rotate fixes

### DIFF
--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -171,11 +171,11 @@ define(function(require) {
         this._transforming = false;
 
         /**
-         * Depending on environment, trigger resize on 'resize' or 'orientationChange'
-         * @type {Boolean}
+         * Trigger resize on 'resize'.
+         * @type {string}
          * @private
          */
-        this._resizeEventType = (typeof dependencies.getWindow().cordova !== 'undefined') ? 'orientationchange' : 'resize';
+        this._resizeEventType = 'resize';
 
         //---------------------------------------------------------
         // Initialization

--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -170,13 +170,6 @@ define(function(require) {
          */
         this._transforming = false;
 
-        /**
-         * Trigger resize on 'resize'.
-         * @type {string}
-         * @private
-         */
-        this._resizeEventType = 'resize';
-
         //---------------------------------------------------------
         // Initialization
         //---------------------------------------------------------
@@ -221,7 +214,7 @@ define(function(require) {
             this._host.removeEventListener(EventTypes.CONTEXT_MENU, handlers[EventTypes.CONTEXT_MENU], false);
 
             var window = dependencies.getWindow();
-            window.removeEventListener(this._resizeEventType, handlers[EventTypes.RESIZE], false);
+            window.removeEventListener('resize', handlers[EventTypes.RESIZE], false);
 
             // Destroy the instance.
             DestroyUtil.destroy(this);
@@ -677,7 +670,7 @@ define(function(require) {
             this._host.addEventListener('contextmenu', handlers[EventTypes.CONTEXT_MENU]);
 
             // Initialize the window resize handler.
-            dependencies.getWindow().addEventListener(this._resizeEventType, handlers[EventTypes.RESIZE]);
+            dependencies.getWindow().addEventListener('resize', handlers[EventTypes.RESIZE]);
         },
 
         /**

--- a/src/scroll_list/ZoomPersistenceRegistrar.js
+++ b/src/scroll_list/ZoomPersistenceRegistrar.js
@@ -24,7 +24,11 @@ define(function() {
             if (currentItemIndex !== scrollList.getCurrentItem().index) {
                 return;
             }
-            var newScale = scrollList.getCurrentItemMap().getScale();
+            var currentItemMap = scrollList.getCurrentItemMap();
+            if (! currentItemMap) {
+                return;
+            }
+            var newScale = currentItemMap.getScale();
             if (newScale === scale) {
                 return;
             }

--- a/src/scroll_list/ZoomPersistenceRegistrar.js
+++ b/src/scroll_list/ZoomPersistenceRegistrar.js
@@ -25,7 +25,7 @@ define(function() {
                 return;
             }
             var currentItemMap = scrollList.getCurrentItemMap();
-            if (! currentItemMap) {
+            if (!currentItemMap) {
                 return;
             }
             var newScale = currentItemMap.getScale();

--- a/test/awesome_map/EventSynthesizerSpec.js
+++ b/test/awesome_map/EventSynthesizerSpec.js
@@ -212,15 +212,15 @@ define(function(require) {
             });
         });
 
-        describe('cordova accomodations', function() {
+        describe('absence of resize-related cordova accomodations', function() {
 
             beforeEach(setup);
             afterEach(teardown);
 
-            it('should use orientationChange if Cordova is defined', function() {
+            it('should use "resize" even if Cordova is defined', function() {
                 window.cordova = {};
                 createSynthesizer();
-                expect(synthesizer._resizeEventType).toBe('orientationchange');
+                expect(synthesizer._resizeEventType).toBe('resize');
                 window.cordova = undefined;
             });
 

--- a/test/awesome_map/EventSynthesizerSpec.js
+++ b/test/awesome_map/EventSynthesizerSpec.js
@@ -212,24 +212,6 @@ define(function(require) {
             });
         });
 
-        describe('absence of resize-related cordova accomodations', function() {
-
-            beforeEach(setup);
-            afterEach(teardown);
-
-            it('should use "resize" even if Cordova is defined', function() {
-                window.cordova = {};
-                createSynthesizer();
-                expect(synthesizer._resizeEventType).toBe('resize');
-                window.cordova = undefined;
-            });
-
-            it('should use "resize" if Cordova is not defined', function() {
-                createSynthesizer();
-                expect(synthesizer._resizeEventType).toBe('resize');
-            });
-        });
-
         describe('invalidate', function() {
 
             beforeEach(setup);

--- a/test/scroll_list/ZoomPersistenceRegistrarSpec.js
+++ b/test/scroll_list/ZoomPersistenceRegistrarSpec.js
@@ -77,5 +77,25 @@ define(function(require){
             var previous = scrollList.getItemMap(3);
             expect(previous.getScale()).toBe(3);
         });
+
+        it('should not throw an error in the scale change handler if the previous map does not exist', function() {
+            var scaleChangeSpy = spyOn(scrollList.onScaleChanged, 'dispatch').andCallFake(function() {
+                var that = this;
+                var args = arguments;
+                // Return undefined for subsequent calls to getCurrentItemMap(),
+                // simulating the issue experienced after rotating on Android.
+                spyOn(scrollList, 'getCurrentItemMap').andReturn(undefined);
+                // Call through to the original method we spied on, and verify
+                // it doesn't throw any errors.
+                expect(function() {
+                    scaleChangeSpy.originalValue.apply(that, args);
+                }).not.toThrow();
+            });
+
+            var currentItemMap = scrollList.getCurrentItemMap();
+            currentItemMap.zoomTo({ scale: currentItemMap.getScale() + 1 });
+
+            expect(scaleChangeSpy.callCount).toBe(1);
+        });
     });
 });


### PR DESCRIPTION
## Problem
In the Android mobile app, rotating the device in certain scenarios resulted in the rendered content to not resize, resize improperly, and disappear.

## Solution
* Perform null checking in `ZoomPersistenceRegistrar` (fixes disappearing content).
* Change `EventSynthesizer._resizeEventType` to always be `"resize"`, even for native mobile apps (fixes improperly-resizing content).

## How to +10/QA

#### Android
* Download [a pre-built .apk I've shared on Google Drive](https://drive.google.com/a/webfilings.com/file/d/0B0HjwL5U4UfLdWpOcHdiWFJ5OE0/view?usp=sharing) and install it.
* OR, build it:
    * Check out wdesk-android branch [WARP-729-test](https://github.com/toddtarbox-wf/wdesk-android/compare/WARP-729-test).
    * Run `grunt`.
    * Build the app in Android Studio with the `betaDebug` variant.
* Launch the app.
* In a multi-page binder (Books viewer):
    *  Zoom in to a page all the way, rotate the device, and verify that:
        * the content resizes properly ([image](https://jira.webfilings.com/secure/attachment/253403/Android%20Rotation%201.png) of improper resizing).
        * there is no "split-view" effect that displays and cuts off two pages ([image](https://jira.webfilings.com/secure/attachment/253404/Android%20Rotation%202.png)).
    *  Rotate a whole bunch and verify that the content resizes properly.
        * _Note: there might be a slight delay (~500ms) in content resizing after rotating, but that can potentially be lowered once the `EventSynthesizer` changes go through._
    *  Zoom out from a page all the way, rotate the device, and verify that the content resizes properly and is displayed (as opposed to missing, leaving you with a grey background).
        * __Note:__ this may only occur on Android Lollipop, so be sure to verify this step on that OS.
* In a multi-page document (Swift viewer), perform general regression testing around rotation.

#### iOS
iOS didn't seem to be affected by these issues, but we should test for regressions:
* Check out wdesk-ios branch [WARP-729-test](https://github.com/bryanhales-wf/wdesk-ios/compare/WARP-729-test).
* Run `grunt`.
* Build the app in Xcode and launch it.
* Test for regressions when rotating in both binders and documents.

## Unit Tests
Added

---
@timmccall-wf @georgelesica-wf @clairesarsam-wf @toddtarbox-wf @bryanhales-wf @brianreed-wf @brentarndorfer-wf 