### PR TITLE
HY-1865: Prevent Swipes After Transforms and Tune Swipe Duration

### DIFF
--- a/src/awesome_map/CustomSwipeGesture.js
+++ b/src/awesome_map/CustomSwipeGesture.js
@@ -38,7 +38,16 @@ define(function(require) {
             swipe_max_touches  : 1,
             swipe_velocity     : 0.7
         },
+        cancel: false,
         handler: function swipeGesture(ev, inst) {
+            // Enforce the max touches option.
+            if (inst.options.swipe_max_touches > 0 &&
+                ev.touches.length > inst.options.swipe_max_touches
+            ) {
+                this.cancel = true;
+                return;
+            }
+
             if (ev.eventType === Hammer.EVENT_START) {
                 moves = [ev, ev];
             }
@@ -46,9 +55,8 @@ define(function(require) {
                 moves.push(ev);
             }
             else if (ev.eventType === Hammer.EVENT_END) {
-                // Enforce the max touchs option.
-                if (inst.options.swipe_max_touches > 0 &&
-                    ev.touches.length > inst.options.swipe_max_touches) {
+                if (this.cancel) {
+                    this.cancel = false;
                     return;
                 }
 

--- a/src/awesome_map/CustomSwipeGesture.js
+++ b/src/awesome_map/CustomSwipeGesture.js
@@ -55,6 +55,8 @@ define(function(require) {
                 moves.push(ev);
             }
             else if (ev.eventType === Hammer.EVENT_END) {
+                // If canceling due to multitouch gesture, then bail out after
+                // flipping the switch so the next swipe begins detection anew.
                 if (this.cancel) {
                     this.cancel = false;
                     return;

--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -77,7 +77,6 @@ define(function(require) {
                 map.addInterceptor(new SwipeNavigationInterceptor(scrollList));
             }
             map.addInterceptor(new SwipeInterceptor({
-                animationDuration: 250,
                 constrainToAxes: true
             }));
             map.addInterceptor(new BoundaryInterceptor({
@@ -184,7 +183,6 @@ define(function(require) {
             if (options.mode === ScrollModes.FLOW) {
                 map.addInterceptor(new DoubleTapZoomInterceptor());
                 map.addInterceptor(new SwipeInterceptor({
-                    animationDuration: 1000,
                     constrainToAxes: true
                 }));
                 if (options.scaleLimits) {

--- a/test/awesome_map/CustomSwipeGestureSpec.js
+++ b/test/awesome_map/CustomSwipeGestureSpec.js
@@ -128,11 +128,17 @@ define(function(require) {
                 swipe_max_touches: 1,
                 swipe_velocity: 0
             });
-            var endEvent = createFakeEvent({
-                eventType: Hammer.EVENT_END,
+            // Simulate a transform
+            var transformEvent = createFakeEvent({
+                eventType: Hammer.EVENT_MOVE,
                 touches: ['faketouch', 'faketouch']
             });
+            var endEvent = createFakeEvent({
+                eventType: Hammer.EVENT_END,
+                touches: ['faketouch']
+            });
             simulateSwipeGestureMoves(hammerInstance, { deltaX: 0 }, { deltaX: 2 });
+            CustomSwipeGesture.handler(transformEvent, hammerInstance);
             CustomSwipeGesture.handler(endEvent, hammerInstance);
             expect(hammerInstance.trigger).not.toHaveBeenCalled();
         });


### PR DESCRIPTION
#### [JIRA Ticket](https://jira.webfilings.com/browse/HY-1865)

Problem
-------

Two problems with swipes:
- The animation is waaay too short for single and peek modes in the ScrollList
- Pinch gestures can trigger swipes! This is very jarring for users.

Solution
--------

- Use the default animation duration for swipes (1 second).
- Never trigger a swipe if the gesture included a pinch.

Unit Tests
----------

Yes

How To +10/QA
-------------

- Open the ScrollList demo on a touch device and go into "flow" mode
- Pinch to zoom in quickly
- Should not end up swiping
- Change to "single" mode
- Zoom in far and swipe
- Should have animation play out over a second (so long as you have enough distance to travel)
- Compare both scenarios with master to see the improvement.