### PR TITLE
HY-1872: Pan Items After Scrolling in !flow Mode

### DIFF
--- a/examples/scroll_list/scroll-list.js
+++ b/examples/scroll_list/scroll-list.js
@@ -107,7 +107,7 @@ define(function(require) {
     var minNumberOfVirtualItems = scrollMode === 'flow' ? (DeviceInfo.desktop ? 15 : 9) : (DeviceInfo.desktop ? 5 : 3);
     var touchScrollingEnabled = Utils.valueOr(urlParams.touchScrollingEnabled, 'true') === 'true';
     var verticalAlign = urlParams.valign || 'auto';
-    var zoomMode = urlParams.scroll && urlParams.scroll !== 'flow';
+    var persistZoom = scrollMode !== 'flow' && (urlParams.persistZoom || false);
 
     var itemSizeCollection = new ItemSizeCollection({
         maxWidth: 1022,
@@ -122,7 +122,7 @@ define(function(require) {
         minNumberOfVirtualItems: minNumberOfVirtualItems,
         mode: scrollMode,
         padding: 1,
-        persistZoom: zoomMode,
+        persistZoom: persistZoom,
         scaleLimits: { minimum: 0.25, maximum: 3 },
         touchScrollingEnabled: touchScrollingEnabled,
         verticalAlign: verticalAlign

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1003,9 +1003,28 @@ define(function(require) {
 
                         var currentItemIndex = layout.getCurrentItemIndex();
                         var itemRange = layout.getRenderedItemRange();
+                        var viewportHeight = layout.getViewportSize().height;
+
                         for (var i = itemRange.startIndex; i <= itemRange.endIndex; i++) {
+                            var itemMap = self.getItemMap(i);
+                            var itemHeight = layout.getItemLayout(i).outerHeight;
+                            var transformY = null;
+                            // For items before the current one, make sure they
+                            // are panned to the bottom of the viewport if they
+                            // overflow vertically.
+                            if (i < currentItemIndex && itemHeight > viewportHeight) {
+                                transformY = viewportHeight - itemHeight;
+                            }
+                            // For items after the current one, make sure they
+                            // are panned to the top of the viewport.
+                            else if (i > currentItemIndex && itemHeight > viewportHeight) {
+                                transformY = 0;
+                            }
                             if (i !== currentItemIndex) {
-                                self.getItemMap(i).zoomTo({ scale: 1 });
+                                itemMap.zoomTo({ scale: 1 });
+                                if (transformY !== null) {
+                                    itemMap.panTo({ y: transformY });
+                                }
                             }
                         }
                     }

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -786,8 +786,11 @@ define(function(require) {
             });
 
             describe('when scrolling in other than "flow" mode', function() {
-                it('should reset the zoom level of all out of view item maps when the scroll completes', function() {
-                    testScrollList({ mode: '!flow' }, function(scrollList) {
+                it('should reset the zoom and position of all out of view item maps when the scroll completes', function() {
+                    // Make sure the viewport is shorter than the items so that
+                    // they overflow vertically.
+                    $host.css({ height: 100 });
+                    testScrollList({ mode: '!flow', fit: 'width' }, function(scrollList) {
                         var listMap = scrollList._listMap;
 
                         // Expect that we panned the list map.
@@ -802,6 +805,7 @@ define(function(require) {
                             for (var i = itemRange.startIndex; i <= itemRange.endIndex; i++) {
                                 var map = _.extend({}, AwesomeMap.prototype);
                                 spyOn(map, 'zoomTo');
+                                spyOn(map, 'panTo');
                                 itemMaps.push(map);
                             }
                         }());
@@ -831,6 +835,12 @@ define(function(require) {
                             }
                             else {
                                 expect(itemMap.zoomTo).toHaveBeenCalledWith({ scale: 1 });
+                                if (i < currentIndexAfterScroll) {
+                                    expect(itemMap.panTo).toHaveBeenCalledWith({ y: -100 });
+                                }
+                                else {
+                                    expect(itemMap.panTo).toHaveBeenCalledWith({ y: 0 });
+                                }
                             }
                         }
                     });


### PR DESCRIPTION
Problem
-------

Items are not repositioned correctly after zooming out and swiping to an adjacent item in `peek` mode, or after changing the current item in `single` mode. The zoom state is restored, but the position is left in an odd state. For example: zoom out on item 1, swipe to item two, then swipe back to item 1 and note that item 1 will be centered in the viewport, rather than have the bottom of the item aligned with the bottom of the viewport. This hurts continuity as you navigate among pages.

Solution
--------

Make sure to pan after scrolling to an item in `peek` or `single` modes.

Unit Tests
----------

Updated.

How To +10/QA
-------------

- Open the ScrollList demo with `fit=width&scroll=peek`. Ensure you have vertical overflow.
- Navigate to page 3 and zoom out to 50% (get the whole page in the viewport)
- Swipe by clicking and dragging until the previous/next item is in view
- Pull the previous page into view
- Should see the page aligned properly with the top (for following page) or bottom (for previous page) of the viewport.

@todbachman-wf 