### PR TITLE
HV-193 Independent ScrollList Padding

### DIFF
--- a/examples/scroll_list/scroll-list.js
+++ b/examples/scroll_list/scroll-list.js
@@ -118,7 +118,7 @@ define(function(require) {
                 right: Number(padding[1]),
                 bottom: Number(padding[2]),
                 left: Number(padding[3])
-            }
+            };
         } else {
             padding = Number(padding);
         }

--- a/examples/scroll_list/scroll-list.js
+++ b/examples/scroll_list/scroll-list.js
@@ -109,6 +109,21 @@ define(function(require) {
     var verticalAlign = urlParams.valign || 'auto';
     var zoomMode = urlParams.scroll && urlParams.scroll !== 'flow';
 
+    var padding = 1;
+    if (urlParams.padding !== undefined) {
+        padding = urlParams.padding.split(',');
+        if (Array.isArray(padding) && padding.length === 4) {
+            padding = {
+                top: Number(padding[0]),
+                right: Number(padding[1]),
+                bottom: Number(padding[2]),
+                left: Number(padding[3])
+            }
+        } else {
+            padding = Number(padding);
+        }
+    }
+
     var itemSizeCollection = new ItemSizeCollection({
         maxWidth: 1022,
         maxHeight: 1022,
@@ -121,7 +136,7 @@ define(function(require) {
         horizontalAlign: horizontalAlign,
         minNumberOfVirtualItems: minNumberOfVirtualItems,
         mode: scrollMode,
-        padding: 1,
+        padding: padding,
         persistZoom: zoomMode,
         scaleLimits: { minimum: 0.25, maximum: 3 },
         touchScrollingEnabled: touchScrollingEnabled,

--- a/src/layouts/ScaleStrategies.js
+++ b/src/layouts/ScaleStrategies.js
@@ -21,11 +21,12 @@ define(function() {
      * Utility to offset a scale to accommodate content margins.
      *
      * @param {number} dimension - The value of the dimension to offset.
-     * @param {number} margin - The margin around the dimensions.
+     * @param {number} marginA - The margin on one side of the item.
+     * @param {number} marginB - The margin on the opposite side of the item.
      * @return {number}
      */
-    function marginScaleOffset(dimension, margin) {
-        return (dimension - margin * 2) / dimension;
+    function marginScaleOffset(dimension, marginA, marginB) {
+        return (dimension - (marginA + marginB)) / dimension;
     }
 
     /**
@@ -45,7 +46,7 @@ define(function() {
          *        The size of the viewport.
          * @param {Array.<{width: number, height: number}>|{width: number, height: number}} itemSizeOrSizes
          *        The size of the item or items to fit.
-         * @param {number} margin
+         * @param {number|{left: number, right: number, top: number, bottom: number}} margin
          *        The margin around the item.
          * @returns {number}
          */
@@ -64,7 +65,7 @@ define(function() {
          *        The size of the viewport.
          * @param {Array.<{height: number}>|{height: number}} itemSizeOrSizes
          *        The size of the item or items to fit.
-         * @param {number} margin
+         * @param {number|{left: number, right: number, top: number, bottom: number}} margin
          *        The margin around the item.
          * @returns {number}
          */
@@ -81,8 +82,18 @@ define(function() {
                 }
             }
 
+            var marginTop;
+            var marginBottom;
+            if (typeof margin === 'object') {
+                marginTop = margin.top;
+                marginBottom = margin.bottom;
+            } else {
+                marginTop = marginBottom = margin;
+            }
+
             // Return the scale to fit height, accounting for page margins.
-            return viewportHeight / maxPageHeight * marginScaleOffset(viewportHeight, margin);
+            return viewportHeight / maxPageHeight *
+                marginScaleOffset(viewportHeight, marginTop, marginBottom);
         },
 
         /**
@@ -102,7 +113,7 @@ define(function() {
          *        The size of the viewport.
          * @param {Array.<{width: number}>|{width: number}} itemSizeOrSizes
          *        The size of the item or items to fit.
-         * @param {number} margin
+         * @param {number|{left: number, right: number, top: number, bottom: number}} margin
          *        The margin around the item.
          * @returns {number}
          */
@@ -119,8 +130,18 @@ define(function() {
                 }
             }
 
+            var marginLeft;
+            var marginRight;
+            if (typeof margin === 'object') {
+                marginLeft = margin.left;
+                marginRight = margin.right;
+            } else {
+                marginLeft = marginRight = margin;
+            }
+
             // Return the scale to fit width, accounting for page margins.
-            return viewportWidth / maxPageWidth * marginScaleOffset(viewportWidth, margin);
+            return viewportWidth / maxPageWidth *
+                marginScaleOffset(viewportWidth, marginLeft, marginRight);
         }
     };
 

--- a/src/layouts/ScaleStrategies.js
+++ b/src/layouts/ScaleStrategies.js
@@ -26,7 +26,11 @@ define(function() {
      * @return {number}
      */
     function marginScaleOffset(dimension, marginA, marginB) {
-        return (dimension - (marginA + marginB)) / dimension;
+        if (dimension === 0) {
+            return 0;
+        } else {
+            return (dimension - (marginA + marginB)) / dimension;
+        }
     }
 
     /**
@@ -80,6 +84,11 @@ define(function() {
                 if (size.height > maxPageHeight) {
                     maxPageHeight = size.height;
                 }
+            }
+
+            // Avoid division by zero below
+            if (maxPageHeight === 0) {
+                return 0;
             }
 
             var marginTop;

--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -92,7 +92,7 @@ define(function(require) {
      * @param {number} [options.minNumberOfVirtualItems=3]
      *        The minimum number of virtual items that the layout will render.
      *
-     * @param {number} [options.padding=0]
+     * @param {number|{left: number, right: number, top: number, bottom: number}} [options.padding=0]
      *        The padding between the rendered layout and the viewport, in pixels.
      *
      * @param {string} [options.verticalAlign='auto']
@@ -831,6 +831,18 @@ define(function(require) {
             var gapBottom = Math.ceil(options.gap / 2);
             var padding = options.padding;
 
+            // Padding may be specified as a single number to be applied to
+            // all sides, or each side can be set independently.
+            var paddingTop, paddingBottom, paddingLeft, paddingRight;
+            if (typeof padding === 'object') {
+                paddingTop = padding.top;
+                paddingBottom = padding.bottom;
+                paddingLeft = padding.left;
+                paddingRight = padding.right;
+            } else {
+                paddingTop = paddingBottom = paddingLeft = paddingRight = padding;
+            }
+
             // Loop through the items.
             var itemSizeCollection = this._itemSizeCollection;
             var numberOfItems = itemSizeCollection.getLength();
@@ -925,17 +937,17 @@ define(function(require) {
                     scaleToFit: scaleToFit,
                     width: Math.round(size.width * scaleToFit),
                     height: Math.round(size.height * scaleToFit),
-                    paddingLeft: padding,
-                    paddingRight: padding
+                    paddingLeft: paddingLeft,
+                    paddingRight: paddingRight
                 });
 
                 if (flow) {
-                    layout.paddingTop = (i === 0) ? padding : gapTop;
-                    layout.paddingBottom = (i === numberOfItems - 1) ? padding : gapBottom;
+                    layout.paddingTop = (i === 0) ? paddingTop : gapTop;
+                    layout.paddingBottom = (i === numberOfItems - 1) ? paddingBottom : gapBottom;
                 }
                 else { // !flow
-                    layout.paddingTop = padding;
-                    layout.paddingBottom = padding;
+                    layout.paddingTop = paddingTop;
+                    layout.paddingBottom = paddingBottom;
                 }
 
                 layout.outerWidth = layout.width + layout.paddingLeft + layout.paddingRight;
@@ -974,7 +986,7 @@ define(function(require) {
             // scale applied to the document.
             if (flow && numberOfItems > 0) {
                 maxWidth = Math.round(
-                    itemSizeCollection.maxWidth * cachedScales.default + (2 * padding)
+                    itemSizeCollection.maxWidth * cachedScales.default + paddingLeft + paddingRight
                 );
             }
 

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -88,7 +88,7 @@ define(function(require) {
      *        The interaction mode for the list.
      *        Can be 'flow', 'peek' or 'single'.
      *
-     * @param {number} [options.padding=0]
+     * @param {number|{left: number, right: number, top: number, bottom: number}} [options.padding=0]
      *        The padding around the list, in pixels.
      *
      * @param {false|Object} [options.scaleLimits]

--- a/test/layouts/ScaleStrategiesSpec.js
+++ b/test/layouts/ScaleStrategiesSpec.js
@@ -20,14 +20,21 @@ define(function(require) {
     var ScaleStrategies = require('wf-js-uicomponents/layouts/ScaleStrategies');
 
     describe('ScaleStrategies', function() {
-        var viewportDimensions = { height: 300, width: 400 };
-        var content = { height: 600, width: 600 };
-        var contents = [
-            { height: 500, width: 200 },
-            { height: 600, width: 600 },
-            { height: 300, width: 1200 }
-        ];
-        var contentMargin = 0;
+        var viewportDimensions;
+        var content;
+        var contents;
+        var contentMargin;
+
+        beforeEach(function() {
+            viewportDimensions = { height: 300, width: 400 };
+            content = { height: 600, width: 600 };
+            contents = [
+                { height: 500, width: 200 },
+                { height: 600, width: 600 },
+                { height: 300, width: 1200 }
+            ];
+            contentMargin = 0;
+        });
 
         describe('when auto-fitting to the viewport', function() {
             it('should return the scale required to fit a single item', function() {
@@ -55,6 +62,23 @@ define(function(require) {
 
                 expect(scale).toBeCloseTo(0.5);
             });
+
+            it('should account for margins above and below items', function() {
+                contentMargin = viewportDimensions.height / 4;
+                var scale = ScaleStrategies.height(viewportDimensions, content, contentMargin);
+
+                expect(scale).toBeCloseTo(0.25);
+            });
+
+            it('should account for margins above and below items independently', function() {
+                contentMargin = {
+                    top: 1 / 8 * viewportDimensions.height,
+                    bottom: 3 / 8 * viewportDimensions.height
+                };
+                var scale = ScaleStrategies.height(viewportDimensions, content, contentMargin);
+
+                expect(scale).toBeCloseTo(0.25);
+            });
         });
 
         describe('when fitting to viewport width', function() {
@@ -66,6 +90,23 @@ define(function(require) {
 
             it('should return the scale required to fit the widest of multiple items', function() {
                 var scale = ScaleStrategies.width(viewportDimensions, contents, contentMargin);
+
+                expect(scale).toBeCloseTo(0.33, 2);
+            });
+
+            it('should account for margins left and right of items', function() {
+                contentMargin = viewportDimensions.width / 4;
+                var scale = ScaleStrategies.width(viewportDimensions, content, contentMargin);
+
+                expect(scale).toBeCloseTo(0.33, 2);
+            });
+
+            it('should account for margins left and right of items independently', function() {
+                contentMargin = {
+                    left: 3 / 8 * viewportDimensions.width,
+                    right: 1 / 8 * viewportDimensions.width
+                };
+                var scale = ScaleStrategies.width(viewportDimensions, content, contentMargin);
 
                 expect(scale).toBeCloseTo(0.33, 2);
             });

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -785,6 +785,17 @@ define(function(require) {
                     });
                 });
 
+                it('should apply padding to the left and right of all items independently', function() {
+                    var padding = { left: 10, right: 30 };
+
+                    layout = createVerticalLayout({ padding: padding });
+
+                    layout.getItemLayouts().forEach(function(item) {
+                        expect(item.paddingLeft).toBe(padding.left);
+                        expect(item.paddingRight).toBe(padding.right);
+                    });
+                });
+
                 describe('flow: true', function() {
 
                     it('should fit the maximum size of items to the viewport', function() {
@@ -824,6 +835,19 @@ define(function(require) {
                         var layoutSize = layout.getSize();
 
                         // 90 = max page width * scale + 2 * padding
+                        expect(layoutSize.width).toEqual(90);
+                    });
+
+                    it('should correctly account for independent left and right padding', function() {
+                        var padding = { left: 10, right: 30, top: 0, bottom: 0 };
+                        var mockScale = 0.5;
+
+                        spyOn(ScaleStrategies, 'auto').andReturn(mockScale);
+
+                        layout = createVerticalLayout({ flow: true, fit: 'auto', padding: padding });
+                        var layoutSize = layout.getSize();
+
+                        // 90 = max page width * scale + padding.left + padding.right
                         expect(layoutSize.width).toEqual(90);
                     });
 
@@ -894,6 +918,21 @@ define(function(require) {
                         });
                     });
 
+                    it('should apply an independent padding to the top of the first item only', function() {
+                        var padding = { top: 20, bottom: 0, left: 0, right: 0 };
+
+                        layout = createVerticalLayout({ flow: true, padding: padding });
+
+                        layout.getItemLayouts().forEach(function(item, index) {
+                            if (index === 0) {
+                                expect(item.paddingTop).toBe(padding.top);
+                            }
+                            else {
+                                expect(item.paddingTop).not.toBe(padding.top);
+                            }
+                        });
+                    });
+
                     it('should apply padding to the bottom of the last item only', function() {
                         var padding = 20;
 
@@ -905,6 +944,21 @@ define(function(require) {
                             }
                             else {
                                 expect(item.paddingBottom).not.toBe(padding);
+                            }
+                        });
+                    });
+
+                    it('should apply an independent padding to the bottom of the last item only', function() {
+                        var padding = { bottom: 20, top: 0, left: 0, right: 0 };
+
+                        layout = createVerticalLayout({ flow: true, padding: padding });
+
+                        layout.getItemLayouts().forEach(function(item, index) {
+                            if (index === itemMetadata.length - 1) {
+                                expect(item.paddingBottom).toBe(padding.bottom);
+                            }
+                            else {
+                                expect(item.paddingBottom).not.toBe(padding.bottom);
                             }
                         });
                     });
@@ -1054,6 +1108,17 @@ define(function(require) {
                         layout.getItemLayouts().forEach(function(item) {
                             expect(item.paddingTop).toBe(padding);
                             expect(item.paddingBottom).toBe(padding);
+                        });
+                    });
+
+                    it('should apply independent padding to the top and bottom of every item', function() {
+                        var padding = { top: 10, bottom: 30, left: 0, right: 0 };
+
+                        layout = createVerticalLayout({ flow: false, padding: padding });
+
+                        layout.getItemLayouts().forEach(function(item) {
+                            expect(item.paddingTop).toBe(padding.top);
+                            expect(item.paddingBottom).toBe(padding.bottom);
                         });
                     });
                 });


### PR DESCRIPTION
**Jira Ticket:** [HY-193](https://jira.webfilings.com/browse/HY-193)

## Problem
In some contexts it would be advantageous to be able to specify the padding around scroll list content independently. For example, perhaps you would like different padding on the left and right side of content versus the top and bottoms of the content.

## Solution
Allow the padding ScrollList option to be specified either as a single number (to be applied to all sides of content) or as an object with left, right, top, and bottom properties.

## How to QA/+10
1. CI Build Passes
1. Check out the `HV-193_custom_padding` branch
1. Run `./init.sh && grunt qa`
1. Open the scrollList demo
1. Change the padding in the demo using the `padding` query param. It can either be a single value, or a comma separated list of 4 values in the order: top, right, bottom, left.
1. Confirm the scroll list layout behaves as expected when the padding is adjusted in different modes
