### PR TITLE
HV-271: Fix Hammer Registration of CustomSwipeGesture

### DIFF
--- a/src/awesome_map/CustomSwipeGesture.js
+++ b/src/awesome_map/CustomSwipeGesture.js
@@ -83,6 +83,22 @@ define(function(require) {
                     inst.trigger(this.name + ev.direction, ev);
                 }
             }
+        },
+
+        /**
+         * This is a custom function, not a standard method on Hammer gestures.
+         * It will replace the existing swipe gesture Hammer uses with this one.
+         */
+        install: function() {
+            // Install into the detection stack, replacing the default gesture.
+            var gestures = Hammer.detection.gestures;
+            for (var i = 0, n = gestures.length; i < n; i++) {
+                if (gestures[i].name === CustomSwipeGesture.name) {
+                    gestures.splice(i, 1);
+                    break;
+                }
+            }
+            Hammer.detection.register(CustomSwipeGesture);
         }
     };
 

--- a/src/awesome_map/CustomSwipeGesture.js
+++ b/src/awesome_map/CustomSwipeGesture.js
@@ -93,12 +93,12 @@ define(function(require) {
             // Install into the detection stack, replacing the default gesture.
             var gestures = Hammer.detection.gestures;
             for (var i = 0, n = gestures.length; i < n; i++) {
-                if (gestures[i].name === CustomSwipeGesture.name) {
+                if (gestures[i].name === this.name) {
                     gestures.splice(i, 1);
                     break;
                 }
             }
-            Hammer.detection.register(CustomSwipeGesture);
+            Hammer.detection.register(this);
             Hammer.gestures.Swipe = this;
         }
     };

--- a/src/awesome_map/CustomSwipeGesture.js
+++ b/src/awesome_map/CustomSwipeGesture.js
@@ -89,7 +89,7 @@ define(function(require) {
          * This is a custom function, not a standard method on Hammer gestures.
          * It will replace the existing swipe gesture Hammer uses with this one.
          */
-        install: function() {
+        register: function() {
             // Install into the detection stack, replacing the default gesture.
             var gestures = Hammer.detection.gestures;
             for (var i = 0, n = gestures.length; i < n; i++) {
@@ -99,6 +99,7 @@ define(function(require) {
                 }
             }
             Hammer.detection.register(CustomSwipeGesture);
+            Hammer.gestures.Swipe = this;
         }
     };
 

--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -35,7 +35,7 @@ define(function(require) {
     var dependencies = {
         createHammerInstance: function(host) {
             /* jshint camelcase:false */
-            Hammer.gestures.Swipe = CustomSwipeGesture;
+            CustomSwipeGesture.install();
             return new Hammer(host, {
                 hold_threshold: 10,
                 hold_timeout: 250,

--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -35,7 +35,7 @@ define(function(require) {
     var dependencies = {
         createHammerInstance: function(host) {
             /* jshint camelcase:false */
-            CustomSwipeGesture.install();
+            CustomSwipeGesture.register();
             return new Hammer(host, {
                 hold_threshold: 10,
                 hold_timeout: 250,

--- a/test/awesome_map/CustomSwipeGestureSpec.js
+++ b/test/awesome_map/CustomSwipeGestureSpec.js
@@ -169,7 +169,7 @@ define(function(require) {
             }
             it('should replace the default Hammer swipe gesture', function() {
                 expect(getCurrentSwipeGesture()).not.toBe(CustomSwipeGesture);
-                CustomSwipeGesture.install();
+                CustomSwipeGesture.register();
                 expect(getCurrentSwipeGesture()).toBe(CustomSwipeGesture);
             });
         });

--- a/test/awesome_map/CustomSwipeGestureSpec.js
+++ b/test/awesome_map/CustomSwipeGestureSpec.js
@@ -153,5 +153,25 @@ define(function(require) {
             CustomSwipeGesture.handler(endEvent, hammerInstance);
             expect(hammerInstance.trigger).not.toHaveBeenCalled();
         });
+
+        describe('installing', function() {
+            function getCurrentSwipeGesture() {
+                var gestures = Hammer.detection.gestures;
+                var currentSwipeGesture;
+                for (var i = 0, n = gestures.length; i < n; i++) {
+                    if (gestures[i].name === CustomSwipeGesture.name) {
+                        // Ensure we don't have two swipe gestures registered.
+                        expect(currentSwipeGesture).toBeUndefined();
+                        currentSwipeGesture = gestures[i];
+                    }
+                }
+                return currentSwipeGesture;
+            }
+            it('should replace the default Hammer swipe gesture', function() {
+                expect(getCurrentSwipeGesture()).not.toBe(CustomSwipeGesture);
+                CustomSwipeGesture.install();
+                expect(getCurrentSwipeGesture()).toBe(CustomSwipeGesture);
+            });
+        });
     });
 });

--- a/test/awesome_map/EventSynthesizerSpec.js
+++ b/test/awesome_map/EventSynthesizerSpec.js
@@ -75,14 +75,14 @@ define(function(require) {
                 /* jshint camelcase:false */
                 beforeEach(function() {
                     $host = $('<div>').css({ position: 'absolute', top: -10000, left: -10000 }).appendTo('body');
-                    spyOn(CustomSwipeGesture, 'install');
+                    spyOn(CustomSwipeGesture, 'register');
                     hammer = EventSynthesizer.dependencies.createHammerInstance($host[0]);
                 });
                 afterEach(function() {
                     $host.remove();
                 });
-                it('should install the CustomSwipeGesture', function() {
-                    expect(CustomSwipeGesture.install).toHaveBeenCalled();
+                it('should register the CustomSwipeGesture', function() {
+                    expect(CustomSwipeGesture.register).toHaveBeenCalled();
                 });
                 it('should set hold threshold to 10 pixels', function() {
                     expect(hammer.options.hold_threshold).toBe(10);

--- a/test/awesome_map/EventSynthesizerSpec.js
+++ b/test/awesome_map/EventSynthesizerSpec.js
@@ -19,6 +19,7 @@ define(function(require) {
 
     var $ = require('jquery');
     var BrowserInfo = require('wf-js-common/BrowserInfo');
+    var CustomSwipeGesture = require('wf-js-uicomponents/awesome_map/CustomSwipeGesture');
     var DestroyUtil = require('wf-js-common/DestroyUtil');
     var EventSynthesizer = require('wf-js-uicomponents/awesome_map/EventSynthesizer');
     var EventTypes = require('wf-js-uicomponents/awesome_map/EventTypes');
@@ -74,10 +75,14 @@ define(function(require) {
                 /* jshint camelcase:false */
                 beforeEach(function() {
                     $host = $('<div>').css({ position: 'absolute', top: -10000, left: -10000 }).appendTo('body');
+                    spyOn(CustomSwipeGesture, 'install');
                     hammer = EventSynthesizer.dependencies.createHammerInstance($host[0]);
                 });
                 afterEach(function() {
                     $host.remove();
+                });
+                it('should install the CustomSwipeGesture', function() {
+                    expect(CustomSwipeGesture.install).toHaveBeenCalled();
                 });
                 it('should set hold threshold to 10 pixels', function() {
                     expect(hammer.options.hold_threshold).toBe(10);


### PR DESCRIPTION
Problem
-------

Incorrect registration of CustomSwipeGesture left default Hammer swipe detection in place. The default detection is terrible, as it does not account for instantaneous velocity, instead using the total delta over the total time from touch to release. This can lead to the following breakdowns:
- False positive if you touch, drag far and fast, pause shortly, then release. 
- False negative if you touch, drag, pause for a long time, then swipe.
- False negative if you touch, drag, reverse direction, then swipe.

Solution
--------

Use the CustomSwipeGesture and register it properly so that consumers don't get the default swipe gesture by accident, which will happen if the consuming app instantiates a Hammer instance before the EventSynthesizer does. :/

Unit Tests
----------

Added

How To +10/QA
-------------

Once integrated into a consuming application, the swiping behavior will be much better:
- No false positives when dragging fast, pausing, then letting go.
- No false negatives when dragging a small amount, pausing for a long time, then swiping.
- No false negatives when dragging in one direction, then swiping in the reverse direction

@bryanhales-wf Please integrate into mobile app and verify behavior is good.
@jeroldalbertson-wf Please integrate into HTML viewer and verify behavior is good; will need to emulate a mobile device to get touch event simulation.

FYI @shanesizer-wf this will resolve the annoying issues you mentioned.