### PR TITLE
HV-309: Limit DoubleTapZoomInterceptor to Touch Events Only

### DIFF
--- a/src/awesome_map/DoubleTapZoomInterceptor.js
+++ b/src/awesome_map/DoubleTapZoomInterceptor.js
@@ -59,7 +59,9 @@ define(function(require) {
          * @param {TransformState} args.currentState
          */
         handleInteraction: function(source, args) {
-            if (args.event.type === EventTypes.DOUBLE_TAP) {
+            if (args.event.type === EventTypes.DOUBLE_TAP &&
+                args.event.source.type.indexOf('touch') === 0
+            ) {
                 this._handleDoubleTap = true;
             }
         },

--- a/test/awesome_map/DoubleTapZoomInterceptorSpec.js
+++ b/test/awesome_map/DoubleTapZoomInterceptorSpec.js
@@ -25,7 +25,7 @@ define(function(require) {
     var TransformState = require('wf-js-uicomponents/awesome_map/TransformState');
 
     function createEvent(type, gesture) {
-        gesture = gesture || new Gesture();
+        gesture = gesture || new Gesture({ source: { type: 'touch' }});
         return new InteractionEvent(type, gesture, gesture);
     }
 
@@ -48,7 +48,7 @@ define(function(require) {
 
         function simulateDoubleTap(originalScale, expectedScale, callback) {
             var state = new TransformState({ scale: originalScale });
-            var gesture = new Gesture();
+            var gesture = new Gesture({ source: { type: 'touch' }});
             var position = { x: 100, y: 50 };
             var doubletap;
             var release;


### PR DESCRIPTION
Problem
-------

Double tap to zoom is not a standard desktop gesture, but is still useful on mobile. 

Solution
--------

Limit the behavior to mobile only

Unit Tests
----------

Updated

How To +10/QA
-------------

- `grunt serve`
- Open the ScrollList demo in Chrome.
- Double tap: _should not zoom_
- Emulate a mobile device using Chrome dev tools
- Double tap: _should zoom to 2x and back to 1x on succeeding zoom_