### PR TITLE
HV-301: Set Default Scale for Items in ScrollList When Fit is None

### DIFF
--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -61,11 +61,6 @@ define(function(require) {
      * @param {Object} [options]
      *        Configuration options for this layout.
      *
-     * @param {number} [options.defaultScale]
-     *        Scale the default size of items by the given value. This setting
-     *        is only relevant when options.fit='none', as other modes will
-     *        size the content to fit the viewport.
-     *
      * @param {number} [options.directionalRenderingWeight=0.8]
      *        Number from 0 to 1 that affects the balance of additional items
      *        added in the current scroll direction. For example, 0.5 will spread
@@ -93,6 +88,11 @@ define(function(require) {
      *
      * @param {string} [options.horizontalAlign='center']
      *        The alignment of the items along the x-axis. Can be 'center' or 'left'.
+     *
+     * @param {number} [options.initialItemScale]
+     *        Scale the default size of items by the given value. This setting
+     *        is only relevant when options.fit='none', as other modes will
+     *        size the content to fit the viewport.
      *
      * @param {number} [options.minNumberOfVirtualItems=3]
      *        The minimum number of virtual items that the layout will render.
@@ -156,7 +156,7 @@ define(function(require) {
          * @type {Object}
          */
         this._options = _.extend({
-            defaultScale: 1,
+            initialItemScale: 1,
             directionalRenderingWeight: 0.8,
             eagerRenderingFactor: 1,
             fit: 'width',
@@ -892,7 +892,7 @@ define(function(require) {
                         width: ScaleStrategies.width(viewportSize, sample, padding),
                         height: ScaleStrategies.height(viewportSize, sample, padding),
                         auto: ScaleStrategies.auto(viewportSize, sample, padding),
-                        none: ScaleStrategies.none() * options.defaultScale
+                        none: ScaleStrategies.none() * options.initialItemScale
                     };
                     scalesToFit.default = Math.min(scalesToFit[fitMode], options.fitUpscaleLimit);
                     return scalesToFit;

--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -61,6 +61,11 @@ define(function(require) {
      * @param {Object} [options]
      *        Configuration options for this layout.
      *
+     * @param {number} [options.defaultScale]
+     *        Scale the default size of items by the given value. This setting
+     *        is only relevant when options.fit='none', as other modes will
+     *        size the content to fit the viewport.
+     *
      * @param {number} [options.directionalRenderingWeight=0.8]
      *        Number from 0 to 1 that affects the balance of additional items
      *        added in the current scroll direction. For example, 0.5 will spread
@@ -151,6 +156,7 @@ define(function(require) {
          * @type {Object}
          */
         this._options = _.extend({
+            defaultScale: 1,
             directionalRenderingWeight: 0.8,
             eagerRenderingFactor: 1,
             fit: 'width',
@@ -882,15 +888,14 @@ define(function(require) {
                             }
                         }
                     }
-                    var scale = ScaleStrategies[fitMode](viewportSize, sample, padding);
-                    var result = {
-                        default: Math.min(scale, options.fitUpscaleLimit),
+                    var scalesToFit = {
                         width: ScaleStrategies.width(viewportSize, sample, padding),
                         height: ScaleStrategies.height(viewportSize, sample, padding),
                         auto: ScaleStrategies.auto(viewportSize, sample, padding),
-                        none: ScaleStrategies.none()
+                        none: ScaleStrategies.none() * options.defaultScale
                     };
-                    return result;
+                    scalesToFit.default = Math.min(scalesToFit[fitMode], options.fitUpscaleLimit);
+                    return scalesToFit;
                 }
                 // If flowing, scale all the items at once.
                 if (flow) {

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -62,11 +62,6 @@ define(function(require) {
      *
      * @param {Object} [options]
      *
-     * @param {number} [options.defaultScale]
-     *        Scale the default size of items by the given value. This setting
-     *        is only relevant when options.fit='none', as other modes will
-     *        size the content to fit the viewport.
-     *
      * @param {boolean} [options.disableScaleTranslation]
      *        Disable the scale translation that makes scale values relative to
      *        the given size of the items. If disabled, scale values are relative
@@ -85,6 +80,11 @@ define(function(require) {
      * @param {string} [options.horizontalAlign='center']
      *        The alignment of the items along the x-axis. Can be 'center' or
      *        'left'.
+     *
+     * @param {number} [options.initialItemScale]
+     *        Scale the default size of items by the given value. This setting
+     *        is only relevant when options.fit='none', as other modes will
+     *        size the content to fit the viewport.
      *
      * @param {number} [options.minNumberOfVirtualItems=3]
      *        The minimum number of virtual items to render at one time.
@@ -412,7 +412,7 @@ define(function(require) {
          * @type {Object}
          */
         this._options = _.extend({
-            defaultScale: 1,
+            initialItemScale: 1,
             disableScaleTranslation: false,
             fit: FitModes.WIDTH,
             fitUpscaleLimit: 1,
@@ -1263,7 +1263,7 @@ define(function(require) {
             var isFlow = options.mode === ScrollModes.FLOW;
 
             this._layout = new VerticalLayout(this._host, this._itemSizesCollection, this._renderer, {
-                defaultScale: options.defaultScale,
+                initialItemScale: options.initialItemScale,
                 minNumberOfVirtualItems: options.minNumberOfVirtualItems,
                 eagerRenderingFactor: isFlow ? 2 : 1,
                 fit: options.fit,

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -62,6 +62,11 @@ define(function(require) {
      *
      * @param {Object} [options]
      *
+     * @param {number} [options.defaultScale]
+     *        Scale the default size of items by the given value. This setting
+     *        is only relevant when options.fit='none', as other modes will
+     *        size the content to fit the viewport.
+     *
      * @param {boolean} [options.disableScaleTranslation]
      *        Disable the scale translation that makes scale values relative to
      *        the given size of the items. If disabled, scale values are relative
@@ -407,6 +412,7 @@ define(function(require) {
          * @type {Object}
          */
         this._options = _.extend({
+            defaultScale: 1,
             disableScaleTranslation: false,
             fit: FitModes.WIDTH,
             fitUpscaleLimit: 1,
@@ -1257,6 +1263,7 @@ define(function(require) {
             var isFlow = options.mode === ScrollModes.FLOW;
 
             this._layout = new VerticalLayout(this._host, this._itemSizesCollection, this._renderer, {
+                defaultScale: options.defaultScale,
                 minNumberOfVirtualItems: options.minNumberOfVirtualItems,
                 eagerRenderingFactor: isFlow ? 2 : 1,
                 fit: options.fit,

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -730,7 +730,7 @@ define(function(require) {
                     expect(layout.getItemLayout(4).scaleToFit).toEqual(autoScale);
                 });
 
-                it('should apply the default scale when not fitting to the viewport', function() {
+                it('should apply the initial item scale when not fitting to the viewport', function() {
                     spyOn(ScaleStrategies, 'auto').andReturn(1);
                     spyOn(ScaleStrategies, 'height').andReturn(1);
                     spyOn(ScaleStrategies, 'width').andReturn(1);
@@ -740,10 +740,10 @@ define(function(require) {
                         { width: 100, height: 200 }
                     ];
                     var itemSizeCollection = createItemSizeCollection(itemMetadata);
-                    var options = { flow: false, fit: 'none', defaultScale: 2, fitUpscaleLimit: 100 };
+                    var options = { flow: false, fit: 'none', initialItemScale: 2, fitUpscaleLimit: 100 };
                     layout = new VerticalLayout($viewport[0], itemSizeCollection, renderer, options);
 
-                    expect(layout.getItemLayout(0).scaleToFit).toEqual(options.defaultScale);
+                    expect(layout.getItemLayout(0).scaleToFit).toEqual(options.initialItemScale);
                 });
 
                 describe('when fit mode is ORIENTATION', function() {

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -730,6 +730,22 @@ define(function(require) {
                     expect(layout.getItemLayout(4).scaleToFit).toEqual(autoScale);
                 });
 
+                it('should apply the default scale when not fitting to the viewport', function() {
+                    spyOn(ScaleStrategies, 'auto').andReturn(1);
+                    spyOn(ScaleStrategies, 'height').andReturn(1);
+                    spyOn(ScaleStrategies, 'width').andReturn(1);
+                    spyOn(ScaleStrategies, 'none').andReturn(1);
+
+                    var itemMetadata = [
+                        { width: 100, height: 200 }
+                    ];
+                    var itemSizeCollection = createItemSizeCollection(itemMetadata);
+                    var options = { flow: false, fit: 'none', defaultScale: 2, fitUpscaleLimit: 100 };
+                    layout = new VerticalLayout($viewport[0], itemSizeCollection, renderer, options);
+
+                    expect(layout.getItemLayout(0).scaleToFit).toEqual(options.defaultScale);
+                });
+
                 describe('when fit mode is ORIENTATION', function() {
                     it('should revert to fit mode of width when in flow mode', function() {
                         var widthScale = 0.3;


### PR DESCRIPTION
Problem
-------

Need a way to scale content that is not fit to the viewport from consuming code.

Solution
--------

Apply a default scale to items when they are not fit to the viewport.
