### PR TITLE
HY-1849 - Handle Hybrid Input Devices

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "1.3.1",
     "hammerjs": "1.0.5",
-    "wf-common": "git://github.com/WebFilings/wf-common#20d43f723ae667bdc9ac0f2647f03d63df884a62"
+    "wf-common": "git://github.com/WebFilings/wf-common#2150d166248f8cc5519b83b088bfaa0c5c9f32cb"
   },
   "devDependencies": {
     "jquery": "2.0.3",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "1.3.1",
     "hammerjs": "1.0.5",
-    "wf-common": "git://github.com/WebFilings/wf-common#1.0.0"
+    "wf-common": "git://github.com/WebFilings/wf-common#29c4c8fca0232a9d92d06728e7aec50a4889709a"
   },
   "devDependencies": {
     "jquery": "2.0.3",

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "1.3.1",
     "hammerjs": "1.0.5",
-    "wf-common": "git://github.com/WebFilings/wf-common#29c4c8fca0232a9d92d06728e7aec50a4889709a"
+    "wf-common": "git://github.com/WebFilings/wf-common#20d43f723ae667bdc9ac0f2647f03d63df884a62"
   },
   "devDependencies": {
     "jquery": "2.0.3",

--- a/examples/scroll_list/scroll-list.js
+++ b/examples/scroll_list/scroll-list.js
@@ -105,7 +105,7 @@ define(function(require) {
     var horizontalAlign = urlParams.halign || 'center';
     var totalPages = urlParams.totalPages !== undefined ? urlParams.totalPages : 100;
     var minNumberOfVirtualItems = scrollMode === 'flow' ? (DeviceInfo.desktop ? 15 : 9) : (DeviceInfo.desktop ? 5 : 3);
-    var touchScrollingEnabled = Utils.valueOr(urlParams.touchScrollingEnabled, 'true') === 'true';
+    var mousePanningEnabled = Utils.valueOr(urlParams.mousePanningEnabled, 'true') === 'true';
     var verticalAlign = urlParams.valign || 'auto';
     var persistZoom = scrollMode !== 'flow' && (urlParams.persistZoom || false);
 
@@ -139,7 +139,7 @@ define(function(require) {
         padding: padding,
         persistZoom: persistZoom,
         scaleLimits: { minimum: 0.25, maximum: 3 },
-        touchScrollingEnabled: touchScrollingEnabled,
+        mousePanningEnabled: mousePanningEnabled,
         verticalAlign: verticalAlign
     });
 

--- a/src/awesome_map/AwesomeMap.js
+++ b/src/awesome_map/AwesomeMap.js
@@ -638,9 +638,6 @@ define(function(require) {
             var queue = this._transformationQueue;
             var event = args.event;
             var eventType = event.type;
-            // TOMTODO - remove console.logs!
-            // console.log(event);
-            console.log(eventType, 'isMouse', EventSource.isMouse(event), 'isTouch', EventSource.isTouch(event), 'isWheel', EventSource.isWheel(event), 'isPointer', EventSource.isPointer(event));
             var done = function() {
                 // Let consumers know that an interaction is complete
                 // when a release event is finished processing.

--- a/src/awesome_map/AwesomeMap.js
+++ b/src/awesome_map/AwesomeMap.js
@@ -20,6 +20,7 @@ define(function(require) {
     var _ = require('lodash');
     var DestroyUtil = require('wf-js-common/DestroyUtil');
     var DOMUtil = require('wf-js-common/DOMUtil');
+    var EventSource = require('wf-js-common/EventSource');
     var EventSynthesizer = require('wf-js-uicomponents/awesome_map/EventSynthesizer');
     var EventTypes = require('wf-js-uicomponents/awesome_map/EventTypes');
     var InteractionSimulator = require('wf-js-uicomponents/awesome_map/InteractionSimulator');
@@ -48,9 +49,9 @@ define(function(require) {
      *        Cancel wheel events so that the browser hosting the map doesn't
      *        bounce when attempting to scroll with a mouse.
      *
-     * @param {boolean} [options.touchScrollingEnabled=true]
-     *        When touch scrolling is enabled, dragging and swiping will scroll
-     *        the list and pan items. When disabled, the following events have
+     * @param {boolean} [options.mousePanningEnabled=true]
+     *        When mouse panning is enabled, dragging will scroll
+     *        the list and pan items. When disabled, the following mouse events have
      *        no effect: drag, swipe, dragstart, dragend
      *
      * @example <caption>Simple Instantiation</caption>
@@ -95,7 +96,7 @@ define(function(require) {
          */
         this._options = _.extend({
             cancelMouseWheelEvents: true,
-            touchScrollingEnabled: true
+            mousePanningEnabled: true
         }, options);
 
         //---------------------------------------------------------
@@ -637,6 +638,9 @@ define(function(require) {
             var queue = this._transformationQueue;
             var event = args.event;
             var eventType = event.type;
+            // TOMTODO - remove console.logs!
+            // console.log(event);
+            console.log(eventType, 'isMouse', EventSource.isMouse(event), 'isTouch', EventSource.isTouch(event), 'isWheel', EventSource.isWheel(event), 'isPointer', EventSource.isPointer(event));
             var done = function() {
                 // Let consumers know that an interaction is complete
                 // when a release event is finished processing.
@@ -927,7 +931,7 @@ define(function(require) {
                 return true;
             }
 
-            if (!this._options.touchScrollingEnabled && (
+            if (!this._options.mousePanningEnabled && EventSource.isMouse(event) && (
                 event.type === EventTypes.DRAG ||
                 event.type === EventTypes.SWIPE ||
                 event.type === EventTypes.DRAG_START ||

--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -307,7 +307,7 @@ define(function(require) {
         _getContextMenuHandler: function() {
             var self = this;
             /**
-             * Handler for double-tap events.
+             * Handler for rightClick/ContentMenu events.
              * @param {Object} event - The source event.
              * @private
              */
@@ -317,7 +317,7 @@ define(function(require) {
                         pageX: event.pageX,
                         pageY: event.pageY
                     },
-                    srcEvent: event.source || event
+                    srcEvent: event
                 };
                 self._dispatchEvent(EventTypes.CONTEXT_MENU, gesture);
             };
@@ -427,7 +427,7 @@ define(function(require) {
                         pageX: event.pageX,
                         pageY: event.pageY
                     },
-                    srcEvent: event.source || event
+                    srcEvent: event
                 };
                 self._dispatchEvent(EventTypes.MOUSE_MOVE, gesture);
             };
@@ -444,7 +444,7 @@ define(function(require) {
                 var gesture = {
                     deltaX: event.distance.x,
                     deltaY: event.distance.y,
-                    srcEvent: event.source || event
+                    srcEvent: event.source // Event.source because this is a normalized event from MouseAdapter.
                 };
 
                 // Dispatch the mouse wheel.
@@ -598,7 +598,7 @@ define(function(require) {
                     self._currentHostRect = hostRect;
 
                     gesture = {
-                        srcEvent: event.source || event,
+                        srcEvent: event,
                         target: self._host
                     };
 

--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -317,7 +317,7 @@ define(function(require) {
                         pageX: event.pageX,
                         pageY: event.pageY
                     },
-                    srcEvent: event.source
+                    srcEvent: event.source || event
                 };
                 self._dispatchEvent(EventTypes.CONTEXT_MENU, gesture);
             };
@@ -427,7 +427,7 @@ define(function(require) {
                         pageX: event.pageX,
                         pageY: event.pageY
                     },
-                    srcEvent: event.source
+                    srcEvent: event.source || event
                 };
                 self._dispatchEvent(EventTypes.MOUSE_MOVE, gesture);
             };
@@ -444,7 +444,7 @@ define(function(require) {
                 var gesture = {
                     deltaX: event.distance.x,
                     deltaY: event.distance.y,
-                    srcEvent: event.source
+                    srcEvent: event.source || event
                 };
 
                 // Dispatch the mouse wheel.
@@ -598,7 +598,7 @@ define(function(require) {
                     self._currentHostRect = hostRect;
 
                     gesture = {
-                        srcEvent: event,
+                        srcEvent: event.source || event,
                         target: self._host
                     };
 

--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -62,7 +62,7 @@ define(function(require) {
             var vAlignAuto = options.verticalAlign === VerticalAlignments.AUTO;
             var map = new AwesomeMap(host, {
                 cancelMouseWheelEvents: false,
-                touchScrollingEnabled: options.touchScrollingEnabled
+                mousePanningEnabled: options.mousePanningEnabled
             });
 
             // Register interceptors.
@@ -172,7 +172,7 @@ define(function(require) {
             var vAlignAuto = options.verticalAlign === VerticalAlignments.AUTO;
             var map = new AwesomeMap(scrollList.getHost(), {
                 cancelMouseWheelEvents: true,
-                touchScrollingEnabled: options.touchScrollingEnabled
+                mousePanningEnabled: options.mousePanningEnabled
             });
 
             // Set content dimensions to the dimensions of the layout.

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -101,10 +101,10 @@ define(function(require) {
      *        set to false to remove the default interceptor or
      *        pass an object with custom options for the interceptor.
      *
-     * @param {boolean} [options.touchScrollingEnabled=true]
-     *        When touch scrolling is enabled, dragging and swiping will scroll
-     *        the list and pan items. When disabled, the mouse wheel and
-     *        scrollbar are the only default means of scrolling.
+     * @param {boolean} [options.mousePanningEnabled=true]
+     *        When mouse panning is enabled, dragging will scroll
+     *        the list and pan items. When disabled, touches, the mouse wheel, and
+     *        scrollbar are the only means of scrolling.
      *
      * @param {boolean} [options.persistZoom=false]
      *        When persistZoom is enabled, when in peek mode the zoom level
@@ -423,7 +423,7 @@ define(function(require) {
             padding: 0,
             persistZoom: false,
             scaleLimits: { minimum: 1, maximum: 3 },
-            touchScrollingEnabled: true,
+            mousePanningEnabled: true,
             verticalAlign: VerticalAlignments.AUTO
         }, options);
 

--- a/test/awesome_map/AwesomeMapSpec.js
+++ b/test/awesome_map/AwesomeMapSpec.js
@@ -428,11 +428,11 @@ define(function(require) {
             });
         });
 
-        describe('setting touchScrollingEnabled to false', function() {
+        describe('setting mousePanningEnabled to false', function() {
             var args = {};
 
             beforeEach(function() {
-                awesomeMap = new AwesomeMap($host[0], { touchScrollingEnabled: false });
+                awesomeMap = new AwesomeMap($host[0], { mousePanningEnabled: false });
                 var gesture = new Gesture();
                 args.event = new InteractionEvent({ simulated: false }, gesture, gesture);
 

--- a/test/awesome_map/AwesomeMapSpec.js
+++ b/test/awesome_map/AwesomeMapSpec.js
@@ -435,6 +435,8 @@ define(function(require) {
                 awesomeMap = new AwesomeMap($host[0], { mousePanningEnabled: false });
                 var gesture = new Gesture();
                 args.event = new InteractionEvent({ simulated: false }, gesture, gesture);
+                var sourceEvent = document.createEvent('MouseEvent');
+                args.event.source = sourceEvent;
 
                 spyOn(awesomeMap._transformationQueue, 'enqueue');
             });

--- a/test/awesome_map/EventSynthesizerSpec.js
+++ b/test/awesome_map/EventSynthesizerSpec.js
@@ -311,7 +311,7 @@ define(function(require) {
 
             it('should dispatch contextmenu events', function() {
                 var eventType = EventTypes.CONTEXT_MENU;
-                var event = { pageX: 10, pageY: 20, source: {} };
+                var event = { pageX: 10, pageY: 20 };
 
                 handlers[eventType](event);
 
@@ -319,7 +319,7 @@ define(function(require) {
                 expect(dispatchEvent.calls[0].args[0]).toBe(eventType);
                 expect(dispatchEvent.calls[0].args[1].center.pageX).toBe(event.pageX);
                 expect(dispatchEvent.calls[0].args[1].center.pageY).toBe(event.pageY);
-                expect(dispatchEvent.calls[0].args[1].srcEvent).toBe(event.source);
+                expect(dispatchEvent.calls[0].args[1].srcEvent).toBe(event);
             });
 
             it('should dispatch double tap events', function() {
@@ -364,7 +364,7 @@ define(function(require) {
 
             it('should dispatch mousemove events', function() {
                 var eventType = EventTypes.MOUSE_MOVE;
-                var event = { pageX: 10, pageY: 20, source: {} };
+                var event = { pageX: 10, pageY: 20 };
 
                 handlers[eventType](event);
 
@@ -372,7 +372,7 @@ define(function(require) {
                 expect(dispatchEvent.calls[0].args[0]).toBe(eventType);
                 expect(dispatchEvent.calls[0].args[1].center.pageX).toBe(event.pageX);
                 expect(dispatchEvent.calls[0].args[1].center.pageY).toBe(event.pageY);
-                expect(dispatchEvent.calls[0].args[1].srcEvent).toBe(event.source);
+                expect(dispatchEvent.calls[0].args[1].srcEvent).toBe(event);
             });
 
             it('should not dispatch mousemove events if dragging', function() {


### PR DESCRIPTION
# Problem
touchScrollingEnabled was a misleading name.  EventSynthesizer was not adding browser events onto Gesture objects.

# Solution
Rename touchScrollingEnabled to mousePanningEnabled.  Change EventSynthesizer to add the event on to the Gesture, if there was no event.source (a hammer event).

# How to Test   
1. CI passes
1. Test with https://github.com/Workiva/wf-js-document-viewer/pull/460