### PR TITLE
HV-157 Fix Annotation Jump Position

### DIFF
--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1052,7 +1052,7 @@ define(function(require) {
                 return;
             }
             var listState = this._listMap.getCurrentTransformState();
-            panToOptions.x = -itemLayout.left * listState.scale;
+            panToOptions.x = listState.translateX;
             panToOptions.y = -itemLayout.top * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
@@ -1066,6 +1066,7 @@ define(function(require) {
                     panToOptions,
                     offset,
                     itemLayout.scaleToFit,
+                    (itemLayout.left + itemLayout.paddingLeft),
                     viewportAnchorLocation
                 );
             }
@@ -1297,13 +1298,13 @@ define(function(require) {
          * Companion method to `scrollToItem` responsible for calculating and
          * applying the offset to the map panToOptions, depending on the viewportAnchorLocation
          */
-        _applyItemOffset: function(panToOptions, offset, itemScaleToFit, viewportAnchorLocation) {
+        _applyItemOffset: function(panToOptions, offset, itemScaleToFit, itemLayoutLeft, viewportAnchorLocation) {
             var viewportSize = this._layout.getViewportSize();
 
             // All of these translations adjust based on scale, so that when a user asks for
             // the item at 200 px, it always yields the same place, regardless of zoom.
             var getTranslation = function(scale) {
-                var scaledOffsetX = itemScaleToFit * offset.x * scale;
+                var scaledOffsetX = (itemScaleToFit * offset.x + itemLayoutLeft) * scale;
                 var scaledOffsetY = itemScaleToFit * offset.y * scale;
                 var translation;
                 if (viewportAnchorLocation === 'top') {
@@ -1348,7 +1349,7 @@ define(function(require) {
             else {
                 var listMapScale = this._listMap.getCurrentTransformState().scale;
                 translation = getTranslation(listMapScale);
-                panToOptions.x += translation.x;
+                panToOptions.x = translation.x;
                 panToOptions.y += translation.y;
             }
         },

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1055,11 +1055,11 @@ define(function(require) {
             //panToOptions.x = listState.translateX;
             panToOptions.currentX = listState.translateX;
             panToOptions.x = panToOptions.currentX;
-            panToOptions.y = -(itemLayout.top + itemLayout.paddingTop) * listState.scale;
+            panToOptions.y = -((itemLayout.top||0)+(itemLayout.paddingTop||0)) * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
             if (options.offset) {
-                panToOptions.x = -(itemLayout.left + itemLayout.paddingLeft) * listState.scale;
+                panToOptions.x = -((itemLayout.left||0)+(itemLayout.paddingLeft||0)) * listState.scale;
                 var viewportAnchorLocation = options.viewportAnchorLocation || 'top';
                 var offset = options.offset || { x: 0, y: 0 };
                 offset.x = offset.x || 0;

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1349,10 +1349,15 @@ define(function(require) {
             else {
                 var listState = this._listMap.getCurrentTransformState();
                 var left; // Calculate the absolute left offset of the AwesomeMap
-                left = this._listMap.getViewportDimensions().width;
-                left = left-this._listMap.getContentDimensions().width;
-                left = (left/2.0);
-                left = itemLayout.left-left;
+                if (this.getOptions().horizontalAlign === 'center') {
+                    left = this._listMap.getViewportDimensions().width;
+                    left = left - this._listMap.getContentDimensions().width;
+                    left = (left / 2.0);
+                    left = itemLayout.left - left;
+                }
+                else if (this.getOptions().horizontalAlignment === 'left') {
+                    left = itemLayout.left;
+                }
 
                 panToOptions.x = -((left||0)+(itemLayout.paddingLeft||0)) * listState.scale;
                 panToOptions.y += -((itemLayout.paddingTop||0) * listState.scale);

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1066,7 +1066,7 @@ define(function(require) {
                     panToOptions,
                     offset,
                     itemLayout.scaleToFit,
-                    (itemLayout.left + itemLayout.paddingLeft),
+                    (itemLayout.left || 0 + itemLayout.paddingLeft || 0),
                     viewportAnchorLocation
                 );
             }

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1052,7 +1052,8 @@ define(function(require) {
                 return;
             }
             var listState = this._listMap.getCurrentTransformState();
-            panToOptions.x = listState.translateX;
+            //panToOptions.x = listState.translateX;
+            panToOptions.x = -itemLayout.left * listState.scale;
             panToOptions.y = -itemLayout.top * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
@@ -1348,7 +1349,8 @@ define(function(require) {
             else {
                 var listMapScale = this._listMap.getCurrentTransformState().scale;
                 translation = getTranslation(listMapScale);
-                panToOptions.x = translation.x;
+                //panToOptions.x = translation.x;
+                //panToOptions.x += translation.x;
                 panToOptions.y += translation.y;
             }
         },

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1054,7 +1054,7 @@ define(function(require) {
             var listState = this._listMap.getCurrentTransformState();
             panToOptions.currentX = listState.translateX;
             panToOptions.x = panToOptions.currentX;
-            panToOptions.y = -((itemLayout.top||0)) * listState.scale;
+            panToOptions.y = -(itemLayout.top||0) * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
             if (options.offset) {

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1054,11 +1054,12 @@ define(function(require) {
             var listState = this._listMap.getCurrentTransformState();
             panToOptions.currentX = listState.translateX;
             panToOptions.x = panToOptions.currentX;
-            panToOptions.y = -((itemLayout.top||0)+(itemLayout.paddingTop||0)) * listState.scale;
+            panToOptions.y = -((itemLayout.top||0)) * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
             if (options.offset) {
                 panToOptions.x = -((itemLayout.left||0)+(itemLayout.paddingLeft||0)) * listState.scale;
+                panToOptions.y += -((itemLayout.paddingTop||0) * listState.scale);
                 var viewportAnchorLocation = options.viewportAnchorLocation || 'top';
                 var offset = options.offset || { x: 0, y: 0 };
                 offset.x = offset.x || 0;

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1053,11 +1053,13 @@ define(function(require) {
             }
             var listState = this._listMap.getCurrentTransformState();
             //panToOptions.x = listState.translateX;
-            panToOptions.x = -itemLayout.left * listState.scale;
-            panToOptions.y = -itemLayout.top * listState.scale;
+            panToOptions.currentX = listState.translateX;
+            panToOptions.x = panToOptions.currentX;
+            panToOptions.y = -(itemLayout.top + itemLayout.paddingTop) * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
             if (options.offset) {
+                panToOptions.x = -(itemLayout.left + itemLayout.paddingLeft) * listState.scale;
                 var viewportAnchorLocation = options.viewportAnchorLocation || 'top';
                 var offset = options.offset || { x: 0, y: 0 };
                 offset.x = offset.x || 0;
@@ -1309,19 +1311,19 @@ define(function(require) {
                 var translation;
                 if (viewportAnchorLocation === 'top') {
                     translation = {
-                        x: 0, // Top has no concept of x.  Keep existing.
+                        x: panToOptions.currentX, // Top has no concept of x.  Keep existing.
                         y: -scaledOffsetY
                     };
                 }
                 else if (viewportAnchorLocation === 'center') {
                     translation = {
-                        x: (viewportSize.width / 2) - scaledOffsetX,
+                        x: (viewportSize.width / 2) - scaledOffsetX + panToOptions.x,
                         y: (viewportSize.height / 2) - scaledOffsetY,
                     };
                 }
                 else if (viewportAnchorLocation === 'bottom') {
                     translation = {
-                        x: 0, // Bottom has no concept of x.  Keep existing.
+                        x: panToOptions.currentX, // Bottom has no concept of x.  Keep existing.
                         y: viewportSize.height - scaledOffsetY
                     };
                 }
@@ -1349,7 +1351,7 @@ define(function(require) {
             else {
                 var listMapScale = this._listMap.getCurrentTransformState().scale;
                 translation = getTranslation(listMapScale);
-                panToOptions.x += translation.x;
+                panToOptions.x = translation.x;
                 panToOptions.y += translation.y;
             }
         },

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1052,7 +1052,6 @@ define(function(require) {
                 return;
             }
             var listState = this._listMap.getCurrentTransformState();
-            //panToOptions.x = listState.translateX;
             panToOptions.x = -itemLayout.left * listState.scale;
             panToOptions.y = -itemLayout.top * listState.scale;
 
@@ -1349,8 +1348,7 @@ define(function(require) {
             else {
                 var listMapScale = this._listMap.getCurrentTransformState().scale;
                 translation = getTranslation(listMapScale);
-                //panToOptions.x = translation.x;
-                //panToOptions.x += translation.x;
+                panToOptions.x += translation.x;
                 panToOptions.y += translation.y;
             }
         },

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1052,14 +1052,12 @@ define(function(require) {
                 return;
             }
             var listState = this._listMap.getCurrentTransformState();
+            panToOptions.x = listState.translateX;
             panToOptions.currentX = listState.translateX;
-            panToOptions.x = panToOptions.currentX;
             panToOptions.y = -(itemLayout.top||0) * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
             if (options.offset) {
-                panToOptions.x = -((itemLayout.left||0)+(itemLayout.paddingLeft||0)) * listState.scale;
-                panToOptions.y += -((itemLayout.paddingTop||0) * listState.scale);
                 var viewportAnchorLocation = options.viewportAnchorLocation || 'top';
                 var offset = options.offset || { x: 0, y: 0 };
                 offset.x = offset.x || 0;
@@ -1068,7 +1066,7 @@ define(function(require) {
                 this._applyItemOffset(
                     panToOptions,
                     offset,
-                    itemLayout.scaleToFit,
+                    itemLayout,
                     viewportAnchorLocation
                 );
             }
@@ -1300,14 +1298,14 @@ define(function(require) {
          * Companion method to `scrollToItem` responsible for calculating and
          * applying the offset to the map panToOptions, depending on the viewportAnchorLocation
          */
-        _applyItemOffset: function(panToOptions, offset, itemScaleToFit, viewportAnchorLocation) {
+        _applyItemOffset: function(panToOptions, offset, itemLayout, viewportAnchorLocation) {
             var viewportSize = this._layout.getViewportSize();
 
             // All of these translations adjust based on scale, so that when a user asks for
             // the item at 200 px, it always yields the same place, regardless of zoom.
             var getTranslation = function(scale) {
-                var scaledOffsetX = itemScaleToFit * offset.x * scale;
-                var scaledOffsetY = itemScaleToFit * offset.y * scale;
+                var scaledOffsetX = itemLayout.scaleToFit * offset.x * scale;
+                var scaledOffsetY = itemLayout.scaleToFit * offset.y * scale;
                 var translation;
                 if (viewportAnchorLocation === 'top') {
                     translation = {
@@ -1349,6 +1347,15 @@ define(function(require) {
             }
             // If not using a item map, we can pan to the position directly.
             else {
+                var listState = this._listMap.getCurrentTransformState();
+                var left; // Calculate the absolute left offset of the AwesomeMap
+                left = this._listMap.getViewportDimensions().width;
+                left = left-this._listMap.getContentDimensions().width;
+                left = (left/2.0);
+                left = itemLayout.left-left;
+
+                panToOptions.x = -((left||0)+(itemLayout.paddingLeft||0)) * listState.scale;
+                panToOptions.y += -((itemLayout.paddingTop||0) * listState.scale);
                 var listMapScale = this._listMap.getCurrentTransformState().scale;
                 translation = getTranslation(listMapScale);
                 panToOptions.x = translation.x;

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1052,7 +1052,6 @@ define(function(require) {
                 return;
             }
             var listState = this._listMap.getCurrentTransformState();
-            //panToOptions.x = listState.translateX;
             panToOptions.currentX = listState.translateX;
             panToOptions.x = panToOptions.currentX;
             panToOptions.y = -((itemLayout.top||0)+(itemLayout.paddingTop||0)) * listState.scale;

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1052,7 +1052,8 @@ define(function(require) {
                 return;
             }
             var listState = this._listMap.getCurrentTransformState();
-            panToOptions.x = listState.translateX;
+            //panToOptions.x = listState.translateX;
+            panToOptions.x = -itemLayout.left * listState.scale;
             panToOptions.y = -itemLayout.top * listState.scale;
 
             // If given a content offset within the item, adjust the panToOptions.
@@ -1066,7 +1067,6 @@ define(function(require) {
                     panToOptions,
                     offset,
                     itemLayout.scaleToFit,
-                    (itemLayout.left || 0 + itemLayout.paddingLeft || 0),
                     viewportAnchorLocation
                 );
             }
@@ -1298,18 +1298,18 @@ define(function(require) {
          * Companion method to `scrollToItem` responsible for calculating and
          * applying the offset to the map panToOptions, depending on the viewportAnchorLocation
          */
-        _applyItemOffset: function(panToOptions, offset, itemScaleToFit, itemLayoutLeft, viewportAnchorLocation) {
+        _applyItemOffset: function(panToOptions, offset, itemScaleToFit, viewportAnchorLocation) {
             var viewportSize = this._layout.getViewportSize();
 
             // All of these translations adjust based on scale, so that when a user asks for
             // the item at 200 px, it always yields the same place, regardless of zoom.
             var getTranslation = function(scale) {
-                var scaledOffsetX = (itemScaleToFit * offset.x + itemLayoutLeft) * scale;
+                var scaledOffsetX = itemScaleToFit * offset.x * scale;
                 var scaledOffsetY = itemScaleToFit * offset.y * scale;
                 var translation;
                 if (viewportAnchorLocation === 'top') {
                     translation = {
-                        x: panToOptions.x, // Top has no concept of x.  Keep existing.
+                        x: 0, // Top has no concept of x.  Keep existing.
                         y: -scaledOffsetY
                     };
                 }
@@ -1321,7 +1321,7 @@ define(function(require) {
                 }
                 else if (viewportAnchorLocation === 'bottom') {
                     translation = {
-                        x: panToOptions.x, // Bottom has no concept of x.  Keep existing.
+                        x: 0, // Bottom has no concept of x.  Keep existing.
                         y: viewportSize.height - scaledOffsetY
                     };
                 }
@@ -1349,7 +1349,7 @@ define(function(require) {
             else {
                 var listMapScale = this._listMap.getCurrentTransformState().scale;
                 translation = getTranslation(listMapScale);
-                panToOptions.x = translation.x;
+                panToOptions.x += translation.x;
                 panToOptions.y += translation.y;
             }
         },

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -854,7 +854,12 @@ define(function(require) {
                 // for now, but it could easily be something else in practice.
                 var scaleToFit = 1;
                 var itemIndex = 2;
-                var itemLayout = { top: pageSize * itemIndex, scaleToFit: scaleToFit };
+                var itemLayout = {
+                    top: pageSize * itemIndex,
+                    scaleToFit: scaleToFit,
+                    left: 0,
+                    paddingLeft: 0
+                };
                 var viewportSize = { width: 200, height: 400 };
                 var offset = { x: 100, y: 200 };
                 var createScrollList = function(options) {

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -786,6 +786,49 @@ define(function(require) {
                 });
             });
 
+            it('should pan to 0,0 for first page', function() {
+                testScrollList(function(scrollList) {
+                    var done = function() {};
+                    var map = scrollList.getListMap();
+                    var currentState = { translateX: 0, scale: 2 };
+                    var itemLayout = {
+                        bottom: 419,
+                        height: 398,
+                        itemIndex: 0,
+                        left: 300,
+                        offsetLeft: 5,
+                        offsetTop: 5,
+                        outerHeight: 419,
+                        outerWidth: 687,
+                        paddingBottom: 5,
+                        paddingLeft: 16,
+                        paddingRight: 16,
+                        paddingTop: 16,
+                        right: 687,
+                        scaleToFit: 0.6498015873015873,
+                        top: 0,
+                        width: 655
+                    };
+
+                    spyOn(map, 'panTo');
+                    spyOn(map, 'getCurrentTransformState').andReturn(currentState);
+                    spyOn(scrollList._layout, 'getItemLayout').andReturn(itemLayout);
+
+                    scrollList.scrollToItem({
+                        index: 1,
+                        done: done
+                    });
+
+                    expect(map.panTo).toHaveBeenCalledWith({
+                        x: 0,
+                        currentX: 0,
+                        y: 0,
+                        duration: 0,
+                        done: jasmine.any(Function)
+                    });
+                });
+            });
+
             describe('when scrolling in other than "flow" mode', function() {
                 it('should reset the zoom and position of all out of view item maps when the scroll completes', function() {
                     // Make sure the viewport is shorter than the items so that

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -854,12 +854,7 @@ define(function(require) {
                 // for now, but it could easily be something else in practice.
                 var scaleToFit = 1;
                 var itemIndex = 2;
-                var itemLayout = {
-                    top: pageSize * itemIndex,
-                    scaleToFit: scaleToFit,
-                    left: 0,
-                    paddingLeft: 0
-                };
+                var itemLayout = { top: pageSize * itemIndex, scaleToFit: scaleToFit };
                 var viewportSize = { width: 200, height: 400 };
                 var offset = { x: 100, y: 200 };
                 var createScrollList = function(options) {

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -778,6 +778,7 @@ define(function(require) {
 
                     expect(map.panTo).toHaveBeenCalledWith({
                         x: currentState.translateX,
+                        currentX: currentState.translateX,
                         y: -itemLayout.top * currentState.scale,
                         duration: 0,
                         done: jasmine.any(Function)
@@ -885,6 +886,7 @@ define(function(require) {
 
                         expect(map.panTo).toHaveBeenCalledWith({
                             x: -(offset.x * scale * scaleToFit) + (viewportSize.width / 2),
+                            currentX: 0,
                             y: -(itemIndex * pageSize * scale * scaleToFit) -
                                (offset.y * scale * scaleToFit) + (viewportSize.height / 2),
                             duration: 0,
@@ -918,6 +920,7 @@ define(function(require) {
 
                         expect(listMap.panTo).toHaveBeenCalledWith({
                             x: 0,
+                            currentX: 0,
                             y: -(itemIndex * pageSize * scale * scaleToFit),
                             duration: 0,
                             done: jasmine.any(Function)
@@ -951,6 +954,7 @@ define(function(require) {
 
                         expect(map.panTo).toHaveBeenCalledWith({
                             x: 0,
+                            currentX: 0,
                             y: -(itemIndex * pageSize * scale * scaleToFit) -
                                (offset.y * scale * scaleToFit),
                             duration: 0,
@@ -984,6 +988,7 @@ define(function(require) {
 
                         expect(listMap.panTo).toHaveBeenCalledWith({
                             x: 0,
+                            currentX: 0,
                             y: -(itemIndex * pageSize * scale * scaleToFit),
                             duration: 0,
                             done: jasmine.any(Function)
@@ -1017,6 +1022,7 @@ define(function(require) {
 
                         expect(map.panTo).toHaveBeenCalledWith({
                             x: 0,
+                            currentX: 0,
                             y: -(itemIndex * pageSize * scale * scaleToFit) -
                               (offset.y * scale * scaleToFit) + viewportSize.height,
                             duration: 0,
@@ -1050,6 +1056,7 @@ define(function(require) {
 
                         expect(listMap.panTo).toHaveBeenCalledWith({
                             x: 0,
+                            currentX: 0,
                             y: -(itemIndex * pageSize * scale * scaleToFit),
                             duration: 0,
                             done: jasmine.any(Function)


### PR DESCRIPTION
JIRA >> https://jira.webfilings.com/browse/HV-157
@tomconnell-wf @todbachman-wf Code Review

## Problem Summary
When clicking on an annotation, the view doesnt quite pan to the comment correctly with respect to the X-axis, particularly on documents with varying sized pages or high zoom levels.

## Solution
Adjusted the formula for calculating the panTo() coordinates to better track annotations on the X-axis

## Unit tests

## How to QA/+10
1. Bower link wf-uicomponents into wf-js-document-viewer, and pip install doc-viewer into bigsky for testing.
2. Create and open a document and/or presentation with varied page widths.  See the test documents attached to the linked Jira ticket for existing documents that can be imported for testing.
3. Create some comments at various locations in the page(s), particularly along the right margin
4. Review the screencast linked and/or description provided in the Jira ticket to familiarize yourself with the specific use-case addressed by this ticket.
5. (With master checked out)
6. Zoom in as far as possible and click on the annotations you created.
7. Verify that the viewport pans to the correct Y-position, but not always the correct X-position (comment isn't actually visible)
8. Checkout this branch of wf-uicomponents
9. Rebuild, Refresh, and Repeat Step 6+7, and verify that your viewport now correctly pans properly on the X-axis, and the comments are now visible.