### PR TITLE
HV-536 Render placholders inside a new placholder-container

### DIFF
--- a/src/scroll_list/PlaceholderRenderer.js
+++ b/src/scroll_list/PlaceholderRenderer.js
@@ -476,18 +476,21 @@ define(function(require) {
             if (this._placeholderContainer) {
                 return this._placeholderContainer;
             }
+            var className = 'scrollList-placeholderContainer';
 
-
+            // Find the placeholder-container if one is already in the DOM
             var scrollList = this._scrollList;
             var listMap = scrollList.getListMap();
             var transformationPlane = listMap.getTransformationPlane();
-            var placeholderContainer = transformationPlane.querySelector('.placeholder-container');
+            var placeholderContainer = transformationPlane.querySelector('.' + className);
             if (placeholderContainer) {
+                this._placeholderContainer = placeholderContainer;
                 return placeholderContainer;
             }
 
+            // Create a placeholder-container if necessary
             placeholderContainer = document.createElement('div');
-            placeholderContainer.className = 'placeholder-container';
+            placeholderContainer.className = className;
             listMap.appendContent(placeholderContainer);
 
             this._placeholderContainer = placeholderContainer;

--- a/src/scroll_list/PlaceholderRenderer.js
+++ b/src/scroll_list/PlaceholderRenderer.js
@@ -34,7 +34,6 @@ define(function(require) {
      * @constructor
      */
     var PlaceholderRenderer = function(scrollList) {
-
         //---------------------------------------------------------
         // Observables
         //---------------------------------------------------------
@@ -121,6 +120,12 @@ define(function(require) {
          * @type {ScrollList}
          */
         this._scrollList = scrollList;
+
+        /**
+         * The div.placeholder-container where placeholders are rendered
+         * @type {HTMLElement}
+         */
+        this._placeholderContainer = null;
     };
 
     PlaceholderRenderer.prototype = {
@@ -158,20 +163,20 @@ define(function(require) {
          */
         appendPlaceholderToScrollList: function(itemLayout, placeholder, update) {
             var scrollList = this._scrollList;
-            var listMap = scrollList.getListMap();
             var layout = scrollList.getLayout();
             var viewportSize = layout.getViewportSize();
             var viewportHeight = viewportSize.height;
+            var element = placeholder.element;
 
+            var placeholderContainer = this.getPlaceholderContainer();
             if (scrollList.getOptions().mode === ScrollModes.FLOW) {
-                var element = placeholder.element;
                 // Adjust the element's left style to account for the fact that
                 // the list map is responsible for positioning content in the viewport.
                 var positionTranslator = scrollList.getPositionTranslator();
                 var adjustedLeft = positionTranslator.getLeftInTransformationPlane(itemLayout.left);
                 element.style.left = adjustedLeft + 'px';
                 if (!update) {
-                    listMap.appendContent(element);
+                    placeholderContainer.appendChild(element);
                 }
             }
             // Only need to handle peek/single modes if not updating an item
@@ -193,13 +198,13 @@ define(function(require) {
                 }
                 var itemMap = placeholder.map;
                 if (!itemMap) {
-                    placeholder.element.removeChild(placeholder.contentContainer);
-                    listMap.appendContent(placeholder.element);
-                    itemMap = AwesomeMapFactory.createItemMap(scrollList, placeholder.element);
+                    element.removeChild(placeholder.contentContainer);
+                    placeholderContainer.appendChild(element);
+                    itemMap = AwesomeMapFactory.createItemMap(scrollList, element);
                     placeholder.map = itemMap;
                 }
                 else {
-                    listMap.appendContent(placeholder.element);
+                    placeholderContainer.appendChild(element);
                 }
                 // Set the static content dimensions and transform to center.
                 itemMap.setContentDimensions({ width: itemWidth, height: itemHeight });
@@ -273,6 +278,7 @@ define(function(require) {
          * @method PlaceholderRenderer#refresh
          */
         refresh: function() {
+            this._placeholderContainer = null;
             var allPlaceholders = this._pool.slice();
             var activePlaceholders = this._placeholders;
 
@@ -305,7 +311,12 @@ define(function(require) {
 
             this.unload(itemIndex);
 
-            this._scrollList.getListMap().removeContent(placeholder.element);
+            var placeholderContainer = this.getPlaceholderContainer();
+
+            if (placeholderContainer.contains(placeholder.element)) {
+                placeholderContainer.removeChild(placeholder.element);
+            }
+
             if (placeholder.map) {
                 placeholder.map.clearContent();
             }
@@ -459,6 +470,28 @@ define(function(require) {
             while (element.firstChild) {
                 element.removeChild(element.firstChild);
             }
+        },
+
+        getPlaceholderContainer: function() {
+            if (this._placeholderContainer) {
+                return this._placeholderContainer;
+            }
+
+
+            var scrollList = this._scrollList;
+            var listMap = scrollList.getListMap();
+            var transformationPlane = listMap.getTransformationPlane();
+            var placeholderContainer = transformationPlane.querySelector('.placeholder-container');
+            if (placeholderContainer) {
+                return placeholderContainer;
+            }
+
+            placeholderContainer = document.createElement('div');
+            placeholderContainer.className = 'placeholder-container';
+            listMap.appendContent(placeholderContainer);
+
+            this._placeholderContainer = placeholderContainer;
+            return placeholderContainer;
         }
     };
 

--- a/test/scroll_list/PlaceholderRendererSpec.js
+++ b/test/scroll_list/PlaceholderRendererSpec.js
@@ -51,8 +51,11 @@ define(function(require) {
                 verticalAlign: VerticalAlignments.AUTO
             };
 
+            var transformationPlane = document.createElement('div');
+
             spyOn(listMap, 'appendContent');
             spyOn(listMap, 'removeContent');
+            spyOn(listMap, 'getTransformationPlane').andReturn(transformationPlane);
             spyOn(layout, 'getViewportSize').andReturn(viewportSize);
             spyOn(layout, 'getSize').andReturn(layoutSize);
             spyOn(scrollList, 'getLayout').andReturn(layout);
@@ -71,6 +74,9 @@ define(function(require) {
 
                 beforeEach(function() {
                     scrollListOptions.mode = ScrollModes.FLOW;
+                    placeholder = {
+                        element: document.createElement('div')
+                    };
                 });
 
                 it('should adjust the left position of the placeholder if layout ' +
@@ -78,7 +84,7 @@ define(function(require) {
                     viewportSize.width = 500;
                     layoutSize.width = 400;
                     itemLayout = { left: 75 };
-                    placeholder = { element: { style: { left: '75px' } } };
+                    placeholder.element.style.left = '75px';
 
                     renderer.appendPlaceholderToScrollList(itemLayout, placeholder);
 
@@ -90,7 +96,7 @@ define(function(require) {
                     viewportSize.width = 400;
                     layoutSize.width = 500;
                     itemLayout = { left: 75 };
-                    placeholder = { element: { style: { left: '75px' } } };
+                    placeholder.element.style.left = '75px';
 
                     renderer.appendPlaceholderToScrollList(itemLayout, placeholder);
 
@@ -103,7 +109,7 @@ define(function(require) {
                     viewportSize.width = 400;
                     layoutSize.width = 500;
                     itemLayout = { left: 0 }; // we expect items to be left-aligned
-                    placeholder = { element: { style: { left: '0px' } } };
+                    placeholder.element.style.left = '0px';
 
                     renderer.appendPlaceholderToScrollList(itemLayout, placeholder);
 
@@ -202,9 +208,13 @@ define(function(require) {
                     });
 
                     it('should append the element to the list map', function() {
+                        var placeholderContainer = renderer.getPlaceholderContainer();
+                        spyOn(placeholderContainer, 'appendChild');
                         renderer.appendPlaceholderToScrollList(itemLayout, placeholder);
 
                         expect(listMap.appendContent)
+                            .toHaveBeenCalledWith(placeholderContainer);
+                        expect(placeholderContainer.appendChild)
                             .toHaveBeenCalledWith(placeholder.element);
                     });
 
@@ -219,9 +229,15 @@ define(function(require) {
                 describe('when item map exists', function() {
 
                     it('should append the element to the list map', function() {
+                        var placeholderContainer = renderer.getPlaceholderContainer();
+                        spyOn(placeholderContainer, 'appendChild');
                         renderer.appendPlaceholderToScrollList(itemLayout, placeholder);
 
-                        expect(listMap.appendContent).toHaveBeenCalledWith(placeholder.element);
+                        expect(listMap.appendContent)
+                            .toHaveBeenCalledWith(placeholderContainer);
+                        expect(placeholderContainer.appendChild)
+                            .toHaveBeenCalledWith(placeholder.element);
+
                     });
                 });
             });
@@ -396,10 +412,12 @@ define(function(require) {
         describe('when removing a placeholder', function() {
 
             var itemLayout;
+            var placeholderContainer;
 
             beforeEach(function() {
                 spyOn(renderer, 'appendPlaceholderToScrollList');
                 itemLayout = new ItemLayout({ itemIndex: 0 });
+                placeholderContainer = renderer.getPlaceholderContainer();
             });
 
             it('should return false if the placeholder does not exist', function() {
@@ -418,10 +436,12 @@ define(function(require) {
             it('should remove the element from the list map', function() {
                 renderer.render(itemLayout);
                 var placeholder = renderer.get(0);
+                spyOn(placeholderContainer, 'contains').andReturn(true);
+                spyOn(placeholderContainer, 'removeChild');
 
                 renderer.remove(0);
 
-                expect(listMap.removeContent).toHaveBeenCalledWith(placeholder.element);
+                expect(placeholderContainer.removeChild).toHaveBeenCalledWith(placeholder.element);
             });
 
             it('should clear the item map', function() {


### PR DESCRIPTION
Problem
================

In flow mode, rendering placeholder elements as direct children of the transformation plane causes problems when other users of the transformation plane inject content as well. Since we remove and append these placeholders as a user scrolls through a document, it can cause any other content that relies on being ordered after the placeholders to not work.

Solution
====================

Render the placeholder elements in a new placeholder-container on the transformation plane. Other users can safely inject content before or after the placeholder-container, and not worry about it being mixed up with placeholders.

Testing
=======================

Run the example scroll list app, and test each scroll mode. Each scroll mode should continue to work, and placeholders should be added and removed as you scroll through the document.

Additionally, test this in your own application, @todbachman-wf.