### PR TITLE
HV-554 Upgrade to lodash 3.6.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
                 paths: {
                     hammerjs: 'bower_components/hammerjs/dist/hammer',
                     jquery: 'bower_components/jquery/jquery',
-                    lodash: 'bower_components/lodash/dist/lodash',
+                    lodash: 'bower_components/lodash/lodash',
                     modernizr: 'bower_components/modernizr/modernizr',
                     'wf-js-common': 'bower_components/wf-common/src',
                     'wf-js-uicomponents': './src'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,9 +10,9 @@ module.exports = function(grunt) {
             },
             requireConfig: {
                 paths: {
-                    hammerjs: 'bower_components/hammerjs/dist/hammer',
-                    jquery: 'bower_components/jquery/jquery',
-                    lodash: 'bower_components/lodash/lodash',
+                    hammerjs: 'bower_components/hammerjs/dist/hammer.min',
+                    jquery: 'bower_components/jquery/jquery.min',
+                    lodash: 'bower_components/lodash/lodash.min',
                     modernizr: 'bower_components/modernizr/modernizr',
                     'wf-js-common': 'bower_components/wf-common/src',
                     'wf-js-uicomponents': './src'

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "smithy.yaml"
   ],
   "dependencies": {
-    "lodash": "1.3.1",
+    "lodash": "3.6.0",
     "hammerjs": "1.0.5",
     "wf-common": "git://github.com/WebFilings/wf-common#1.0.1"
   },

--- a/examples/require.config.js
+++ b/examples/require.config.js
@@ -2,9 +2,9 @@ requirejs.config({
     baseUrl: './',
     paths: {
         bowser: '../../bower_components/bowser/bowser',
-        hammerjs: '../../bower_components/hammerjs/dist/hammer',
-        jquery: '../../bower_components/jquery/jquery',
-        lodash: '../../bower_components/lodash/dist/lodash',
+        hammerjs: '../../bower_components/hammerjs/dist/hammer.min',
+        jquery: '../../bower_components/jquery/jquery.min',
+        lodash: '../../bower_components/lodash/lodash.min',
         modernizr: '../../bower_components/modernizr/modernizr',
         'hammerjs.fakemultitouch': '../vendor/hammer.fakemultitouch',
         'hammerjs.showtouches': '../vendor/hammer.showtouches',


### PR DESCRIPTION
## Problem:
We are using an old version of lodash. The latest version offers features we'd like to take advantage of.

## Solution:
Updated lodash dependency in `bower.json`.

## +10/QA:
1. CI build passes
1. Open the demos and confirm everything behaves as expected
1. Test in your own application