### PR TITLE
HY-2862 Increase size of minimum area on track button on scroll bar

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 wf-js-uicomponents
-Copyright 2014 WebFilings, LLC
+Copyright 2015 Workiva, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/Workiva/wf-uicomponents.png)](https://travis-ci.org/Workiva/wf-uicomponents)
 
-WebFilings JavaScript UI Components
+Workiva JavaScript UI Components
 ================================================================================
 
 > Mobile-optimized, composable UI components that support a rich HTML5 user experience.
@@ -54,7 +54,7 @@ Consuming This Library
 $ npm install -g bower
 
 # install this package
-$ bower install git@github.com:WebFilings/wf-uicomponents.git#{version}
+$ bower install git@github.com:Workiva/wf-uicomponents.git#{version}
 ```
 
 - In your requirejs configuration, ensure the following config exists
@@ -87,7 +87,7 @@ Development: Getting Started
 
 ```bash
 # clone the repo
-$ git clone git@github.com:WebFilings/wf-uicomponents.git
+$ git clone git@github.com:Workiva/wf-uicomponents.git
 $ cd wf-uicomponents
 
 # install global tools if you haven't already
@@ -154,7 +154,7 @@ Familiarize yourself with the package managers we use:
 Development: Process
 --------------------------------------------------------------------------------
 
-This project uses [wf-grunt](https://github.com/WebFilings/wf-grunt#task-reference).
+This project uses [wf-grunt](https://github.com/Workiva/wf-grunt#task-reference).
 Please see that repo for more information.
 
 [Node]: http://nodejs.org/api/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/WebFilings/wf-uicomponents.png)](https://travis-ci.org/WebFilings/wf-uicomponents)
+[![Build Status](https://travis-ci.org/Workiva/wf-uicomponents.png)](https://travis-ci.org/Workiva/wf-uicomponents)
 
 WebFilings JavaScript UI Components
 ================================================================================

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ There are three interceptors provided out of the box:
 - **ScaleInterceptor**: Restricts zooming of content to specified scale limits.
 - **SwipeInterceptor**: Animates a swipe when swipe events are transformed.
 
-[Demo](https://webfilings.box.com/shared/static/4aj3gfi3u2hmkqueashm.mov)
-
 #### ScrollList
 
 The ScrollList renders a virtualized list of items in its host element.

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "lodash": "3.6.0",
     "hammerjs": "1.0.5",
-    "wf-common": "git://github.com/WebFilings/wf-common#1.1.1"
+    "wf-common": "git://github.com/Workiva/wf-common#1.1.1"
   },
   "devDependencies": {
     "jquery": "2.0.3",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-WebFilings JavaScript UI Components
+Workiva JavaScript UI Components
 ===================================
 
 > UI components that support a rich HTML5 user experience. _Optimized for mobile!_

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,6 @@ There are three interceptors provided out of the box:
 - **ScaleInterceptor**: Restricts zooming of content to specified scale limits.
 - **SwipeInterceptor**: Animates a swipe when swipe events are transformed.
 
-[Demo](https://webfilings.box.com/shared/static/4aj3gfi3u2hmkqueashm.mov)
-
 #### {@link ScrollList}
 
 The ScrollList renders a virtualized list of items in its host element.

--- a/examples/vendor/wf-uicomponents.min.js
+++ b/examples/vendor/wf-uicomponents.min.js
@@ -1,4 +1,4 @@
-/*! WebFilings Copyright (c) 2014 */
+/*! Copyright 2015 Workiva, Inc. */
 
 /**
  * @license almond 0.2.9 Copyright (c) 2011-2014, The Dojo Foundation All Rights Reserved.

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>WebFilings UI Components</title>
+    <title>Workiva UI Components</title>
 </head>
 <body>
-    <h1>WebFilings UI Components</h1>
+    <h1>Workiva UI Components</h1>
 
     <h3>Code Quality</h3>
     <ul>

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git://github.com/WebFilings/wf-uicomponents.git"
+    "url": "git://github.com/Workiva/wf-uicomponents.git"
   },
   "readmeFilename": "README.md",
   "devDependencies": {
     "almond": "~0.2.7",
     "grunt": "^0.4.5",
     "grunt-contrib-requirejs": "~0.4.1",
-    "wf-grunt": "git://github.com/WebFilings/wf-grunt.git#0.4.0"
+    "wf-grunt": "git://github.com/Workiva/wf-grunt.git#0.4.0"
   },
   "jspm": {
     "directories": {

--- a/scripts/build/start.frag
+++ b/scripts/build/start.frag
@@ -1,4 +1,4 @@
-/*! WebFilings Copyright (c) 2014 */
+/*! Copyright 2015 Workiva, Inc. */
 
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {

--- a/src/awesome_map/AwesomeMap.js
+++ b/src/awesome_map/AwesomeMap.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/BoundaryInterceptor.js
+++ b/src/awesome_map/BoundaryInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ define(function(require) {
      */
     var INERTIAL_SCALE_FACTOR = 4;
 
-    /** 
+    /**
      * This constant defines the default minimum number of pixels beyond the boundary a
      * scroll event must reach for boundary events to be fired.
      * @type {number}
@@ -119,7 +119,7 @@ define(function(require) {
      *
      * @param {number} [options.boundarySensitivity=DEFAULT_BOUNDARY_SENSITIVITY]
      *        This value defines the minimum number of pixels beyond the boundary a scroll event
-     *        must reach for boundary events to be fired, so that light touches and small scrolls 
+     *        must reach for boundary events to be fired, so that light touches and small scrolls
      *        (by default) wont fire events constantly.  A value of 0 will cause every event which
      *        passes a boundary to fire a boundary event.
      *
@@ -185,7 +185,7 @@ define(function(require) {
         this.onScrollPastBoundary = Observable.newObservable();
 
         /**
-         * A list of boundaries that have been in view since the last completed user event 
+         * A list of boundaries that have been in view since the last completed user event
          * @type {Array.<BoundaryType>}
          * @private
          */
@@ -229,7 +229,7 @@ define(function(require) {
         this._pinToTop = !!options.pinToTop;
 
         /**
-         * A dispatcher for BoundaryEvents.  Uses a front-firing debouncer for each 
+         * A dispatcher for BoundaryEvents.  Uses a front-firing debouncer for each
          * boundary type instead of a debounced master dispatcher so that the events dont
          * block each other.
          * @type {Function}
@@ -350,14 +350,14 @@ define(function(require) {
                 break;
 
             case EventTypes.DRAG_END:
-                /* jshint -W086 */// Expected break statement 
+                /* jshint -W086 */// Expected break statement
 
                 this._determineBoundaryVisibility();
                 // Fall through
 
             case EventTypes.DRAG:
             case EventTypes.DRAG_START:
-                /* jshint +W086 */// Expected break statement             
+                /* jshint +W086 */// Expected break statement
 
                 this._checkForBoundaryEvents(targetState);
                 if (!event.simulated && this._mode.x === Modes.SLOW) {

--- a/src/awesome_map/BoundaryTypes.js
+++ b/src/awesome_map/BoundaryTypes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Workiva, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/DoubleTapZoomInterceptor.js
+++ b/src/awesome_map/DoubleTapZoomInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/EasingFunctions.js
+++ b/src/awesome_map/EasingFunctions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/EventSynthesizer.js
+++ b/src/awesome_map/EventSynthesizer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/EventTypes.js
+++ b/src/awesome_map/EventTypes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/Gesture.js
+++ b/src/awesome_map/Gesture.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/InteractionEvent.js
+++ b/src/awesome_map/InteractionEvent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/InteractionSimulator.js
+++ b/src/awesome_map/InteractionSimulator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/InterceptorMixin.js
+++ b/src/awesome_map/InterceptorMixin.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/ScaleInterceptor.js
+++ b/src/awesome_map/ScaleInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/SwipeInterceptor.js
+++ b/src/awesome_map/SwipeInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/TransformState.js
+++ b/src/awesome_map/TransformState.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/TransformUtil.js
+++ b/src/awesome_map/TransformUtil.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/Transformation.js
+++ b/src/awesome_map/Transformation.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/awesome_map/TransformationQueue.js
+++ b/src/awesome_map/TransformationQueue.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/FitModes.js
+++ b/src/layouts/FitModes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/HorizontalAlignments.js
+++ b/src/layouts/HorizontalAlignments.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/ItemLayout.js
+++ b/src/layouts/ItemLayout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/ItemSizeCollection.js
+++ b/src/layouts/ItemSizeCollection.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/Orientations.js
+++ b/src/layouts/Orientations.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/ScaleStrategies.js
+++ b/src/layouts/ScaleStrategies.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/VerticalAlignments.js
+++ b/src/layouts/VerticalAlignments.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/layouts/VerticalLayout.js
+++ b/src/layouts/VerticalLayout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_bar/ScrollBar.js
+++ b/src/scroll_bar/ScrollBar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_bar/ScrollBar.js
+++ b/src/scroll_bar/ScrollBar.js
@@ -20,7 +20,7 @@ define(function(require) {
     var EventTypes = require('wf-js-uicomponents/awesome_map/EventTypes');
     var DestroyUtil = require('wf-js-common/DestroyUtil');
 
-    var DEFAULT_MIN_SIZE = 16;
+    var DEFAULT_MIN_SIZE = 45;
     var DEFAULT_SCROLLER_Z_INDEX = 3;
     var DEFAULT_SCROLLER_CLASS = 'scroller';
     var DEFAULT_VERT_SCROLLER_CLASS = 'vertical-scroller';

--- a/src/scroll_list/AwesomeMapFactory.js
+++ b/src/scroll_list/AwesomeMapFactory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/KeyNavigator.js
+++ b/src/scroll_list/KeyNavigator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/MouseWheelNavigationInterceptor.js
+++ b/src/scroll_list/MouseWheelNavigationInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/PeekInterceptor.js
+++ b/src/scroll_list/PeekInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/PlaceholderRenderer.js
+++ b/src/scroll_list/PlaceholderRenderer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/PositionTranslator.js
+++ b/src/scroll_list/PositionTranslator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/RenderingHooksInterceptor.js
+++ b/src/scroll_list/RenderingHooksInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/ScaleTranslator.js
+++ b/src/scroll_list/ScaleTranslator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/ScrollList.js
+++ b/src/scroll_list/ScrollList.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -410,7 +410,7 @@ define(function(require) {
         /*
          * This function is used to handle an edge case in SINGLE and PEEK modes
          * where, upon scrolling to the top or bottom item in the ScrollList, the
-         * boundaries immediately are visible, allowing the same event(s) which 
+         * boundaries immediately are visible, allowing the same event(s) which
          * triggered the page transition to also fire boundary events.  However,
          * this is not desired behavior.  In these cases, events are blocked
          * temporarily.
@@ -1444,7 +1444,7 @@ define(function(require) {
 
             switch (this._options.mode) {
             case ScrollModes.FLOW:
-                // Propagate all events; there is only one Awesome map, and its 
+                // Propagate all events; there is only one Awesome map, and its
                 // boundaries are the same as the ScrollLists'
                 propagate = true;
                 break;

--- a/src/scroll_list/ScrollModes.js
+++ b/src/scroll_list/ScrollModes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/StopPropagationInterceptor.js
+++ b/src/scroll_list/StopPropagationInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/SwipeNavigationInterceptor.js
+++ b/src/scroll_list/SwipeNavigationInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/ViewportResizeInterceptor.js
+++ b/src/scroll_list/ViewportResizeInterceptor.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/scroll_list/ZoomPersistenceRegistrar.js
+++ b/src/scroll_list/ZoomPersistenceRegistrar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/AwesomeMapSpec.js
+++ b/test/awesome_map/AwesomeMapSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/BoundaryInterceptorSpec.js
+++ b/test/awesome_map/BoundaryInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/DoubleTapZoomInterceptorSpec.js
+++ b/test/awesome_map/DoubleTapZoomInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/EasingFunctionsSpec.js
+++ b/test/awesome_map/EasingFunctionsSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/EventSynthesizerSpec.js
+++ b/test/awesome_map/EventSynthesizerSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/GestureSpec.js
+++ b/test/awesome_map/GestureSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/InteractionSimulatorSpec.js
+++ b/test/awesome_map/InteractionSimulatorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/InterceptorMixinSpec.js
+++ b/test/awesome_map/InterceptorMixinSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/ScaleInterceptorSpec.js
+++ b/test/awesome_map/ScaleInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/SwipeInterceptorSpec.js
+++ b/test/awesome_map/SwipeInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/TransformStateSpec.js
+++ b/test/awesome_map/TransformStateSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/TransformUtilSpec.js
+++ b/test/awesome_map/TransformUtilSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/TransformationQueueSpec.js
+++ b/test/awesome_map/TransformationQueueSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/awesome_map/TransformationSpec.js
+++ b/test/awesome_map/TransformationSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/layouts/ItemLayoutSpec.js
+++ b/test/layouts/ItemLayoutSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/layouts/ScaleStrategiesSpec.js
+++ b/test/layouts/ScaleStrategiesSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/layouts/VerticalLayoutSpec.js
+++ b/test/layouts/VerticalLayoutSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_bar/ScrollBarSpec.js
+++ b/test/scroll_bar/ScrollBarSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/AwesomeMapFactorySpec.js
+++ b/test/scroll_list/AwesomeMapFactorySpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/MouseWheelNavigationInterceptorSpec.js
+++ b/test/scroll_list/MouseWheelNavigationInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/PeekInterceptorSpec.js
+++ b/test/scroll_list/PeekInterceptorSpec.js
@@ -1,5 +1,5 @@
  /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/PlaceholderRendererSpec.js
+++ b/test/scroll_list/PlaceholderRendererSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/RenderingHooksInterceptorSpec.js
+++ b/test/scroll_list/RenderingHooksInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/ScaleTranslatorSpec.js
+++ b/test/scroll_list/ScaleTranslatorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/ScrollListSpec.js
+++ b/test/scroll_list/ScrollListSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1485,7 +1485,7 @@ define(function(require) {
                 });
             });
         });
-    
+
         describe('_shouldPropagateBoundaryEvent', function() {
             function testBoundaryEvent(scrollList, boundary, isCalled) {
                 spyOn(scrollList.onScrollPastBoundary,'dispatch');

--- a/test/scroll_list/StopPropogationInterceptorSpec.js
+++ b/test/scroll_list/StopPropogationInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/SwipeNavigationInterceptorSpec.js
+++ b/test/scroll_list/SwipeNavigationInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/scroll_list/ViewportResizeInterceptorSpec.js
+++ b/test/scroll_list/ViewportResizeInterceptorSpec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 WebFilings, LLC
+ * Copyright 2015 Workiva, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Problem: "When opening a large document in viewer, the hit area of the tracking button on the scroll bar becomes too small. We need to have a minimum size that feels larger - somewhere in the vicinity of 45px vertical."

Solution: Make it so. I noticed that we could have passed this in as an option (and still can), but I didn't want to trace the option passing all the way down from doc_viewer. Plus, if 45px really is a UX minimum for usability, then it should be the default min size, so...

CR: @georgelesica-wf et al
### To +10
- [ ] UX sign-off on the screenshot below (that's as small as the pill will ever get). @jasonmoore-wf (or @ephierisho-wf)
- [x] `grunt qa` and open http://localhost:9000/examples/scroll_list/?totalPages=7. Now change total pages to >7 and verify that the pill never gets smaller than 45px.
  ![new](https://cloud.githubusercontent.com/assets/6391742/9921039/cb459c6e-5c96-11e5-8c04-724b54307979.png)

This is how small it used to be:
![old](https://cloud.githubusercontent.com/assets/6391742/9921083/4b3c57fa-5c97-11e5-9e3e-c2ec8818f9b2.png)
